### PR TITLE
Add MitID authentication, replacing deprecated Unilogin flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2026-05-02
+
+### Added
+- **MitID authentication**: Replaces the deprecated Unilogin password flow with the same
+  MitID OAuth 2.0 + SAML flow used by the upstream `scaarup/aula` integration.
+  - Supports both **MitID app** (QR code scan) and **MitID code reader** (token) methods
+  - Multi-step config flow with a dedicated web view at
+    `/api/aula_easyiq/auth/<flow_id>` for displaying QR codes and identity selection
+  - Refresh-token-based renewal of access tokens, persisted in the config entry
+  - Reauth flow triggered automatically when refresh fails (`ConfigEntryAuthFailed`)
+- **Vendored `aula_login_client` package** (incl. `mitid_browserclient`) for the MitID
+  flow, sourced from `scaarup/aula` (MIT). Credit retained.
+
+### Changed
+- **`manifest.json` requirements** now include `pycryptodome`, `qrcode`, `requests`,
+  `beautifulsoup4`, and `lxml` for the MitID flow.
+- **Config entry schema (VERSION = 2)** now stores `mitid_username`, `auth_method`,
+  `access_token`, `refresh_token`, `token_expires_at` instead of `username` / `password`.
+- **Aula API calls** now pass `access_token` as a query parameter (the MitID OAuth
+  flow's tokens replace cookie-based session auth).
+
+### Removed
+- The Unilogin username/password login flow in `client.py`. Aula has deprecated this
+  authentication method, so it no longer works in practice.
+
+### Migration
+- Existing 0.4.x users will receive a reauth prompt on the next restart and need
+  to re-authenticate with MitID once.
+
 ## [0.4.0] - 2025-09-28
 
 ### Added

--- a/custom_components/aula_easyiq/__init__.py
+++ b/custom_components/aula_easyiq/__init__.py
@@ -8,9 +8,21 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import async_get_integration
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, ConfigEntryAuthFailed
 
-from .const import DOMAIN, STARTUP
+from .const import (
+    AUTH_METHOD_APP,
+    CONF_ACCESS_TOKEN,
+    CONF_AUTH_METHOD,
+    CONF_MITID_IDENTITY,
+    CONF_MITID_PASSWORD,
+    CONF_MITID_TOKEN,
+    CONF_MITID_USERNAME,
+    CONF_REFRESH_TOKEN,
+    CONF_TOKEN_EXPIRES_AT,
+    DOMAIN,
+    STARTUP,
+)
 from .client import EasyIQClient
 from .sensor import EasyIQDataUpdateCoordinator
 
@@ -23,51 +35,118 @@ PLATFORMS: list[Platform] = [
 ]
 
 
+def _stored_tokens_from_entry(entry: ConfigEntry) -> dict | None:
+    """Build the tokens dict the client expects from a config entry."""
+    if CONF_ACCESS_TOKEN not in entry.data:
+        return None
+    return {
+        "access_token": entry.data[CONF_ACCESS_TOKEN],
+        "refresh_token": entry.data.get(CONF_REFRESH_TOKEN, ""),
+        "expires_at": entry.data.get(CONF_TOKEN_EXPIRES_AT, 0),
+        "token_type": "Bearer",
+    }
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up EasyIQ from a config entry."""
     integration = await async_get_integration(hass, DOMAIN)
     _LOGGER.info(STARTUP, integration.version)
-    
+
     hass.data.setdefault(DOMAIN, {})
-    
+
+    mitid_username = entry.data.get(CONF_MITID_USERNAME)
+    if not mitid_username:
+        # Old config entries from the unilogin era have no MitID username and
+        # cannot work anymore. Trigger a reauth so the user can re-enter MitID.
+        _LOGGER.warning(
+            "Config entry has no MitID username (legacy unilogin entry?); "
+            "triggering reauth"
+        )
+        raise ConfigEntryAuthFailed(
+            "Aula now requires MitID; please re-authenticate the EasyIQ integration."
+        )
+
+    auth_method = entry.data.get(CONF_AUTH_METHOD, AUTH_METHOD_APP)
+    mitid_password = entry.data.get(CONF_MITID_PASSWORD)
+    mitid_token = entry.data.get(CONF_MITID_TOKEN)
+    mitid_identity = entry.data.get(CONF_MITID_IDENTITY, 1)
+    stored_tokens = _stored_tokens_from_entry(entry)
+
+    def token_update_callback(tokens: dict) -> None:
+        """Persist refreshed tokens back into the config entry (thread-safe)."""
+        try:
+            asyncio.run_coroutine_threadsafe(
+                async_update_tokens(hass, entry, tokens),
+                hass.loop,
+            ).result(timeout=5)
+        except Exception as err:  # pragma: no cover - best-effort persistence
+            _LOGGER.warning("Failed to persist refreshed tokens: %s", err)
+
     # Create the EasyIQ client
     client = EasyIQClient(
-        username=entry.data["username"],
-        password=entry.data["password"],
+        mitid_username=mitid_username,
+        auth_method=auth_method,
+        mitid_password=mitid_password,
+        mitid_token=mitid_token,
+        mitid_identity=mitid_identity,
+        stored_tokens=stored_tokens,
+        token_update_callback=token_update_callback,
     )
-    
+
+    # Validate / refresh tokens (or trigger reauth if not possible).
+    try:
+        login_ok = await hass.async_add_executor_job(client.login)
+    except Exception as err:
+        _LOGGER.error("MitID login failed: %s", err)
+        raise ConfigEntryAuthFailed(
+            "MitID re-authentication required. Please reconfigure EasyIQ."
+        ) from err
+    if not login_ok:
+        raise ConfigEntryAuthFailed(
+            "MitID re-authentication required. Please reconfigure EasyIQ."
+        )
+
     # Create the data update coordinator
     coordinator = EasyIQDataUpdateCoordinator(hass, client, entry)
-    
+
     # Perform initial data fetch
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:
         _LOGGER.error("Failed to perform initial data fetch: %s", err)
         raise ConfigEntryNotReady from err
-    
-    # Store coordinator and client in hass data
+
     hass_data = {
         "coordinator": coordinator,
         "client": client,
     }
-    
+
     # Registers update listener to update config entry when options are updated.
     unsub_options_update_listener = entry.add_update_listener(options_update_listener)
-    # Store a reference to the unsubscribe function to cleanup if an entry is unloaded.
     hass_data["unsub_options_update_listener"] = unsub_options_update_listener
     hass.data[DOMAIN][entry.entry_id] = hass_data
 
-    # Forward the setup to the sensor, binary_sensor, and calendar platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    
+
     return True
+
+
+async def async_update_tokens(
+    hass: HomeAssistant, entry: ConfigEntry, tokens: dict
+) -> None:
+    """Persist refreshed OAuth tokens into the config entry without reloading."""
+    new_data = dict(entry.data)
+    new_data[CONF_ACCESS_TOKEN] = tokens.get("access_token", "")
+    new_data[CONF_REFRESH_TOKEN] = tokens.get("refresh_token", "")
+    new_data[CONF_TOKEN_EXPIRES_AT] = tokens.get("expires_at", 0)
+    hass.config_entries.async_update_entry(entry, data=new_data)
+    _LOGGER.debug("Refreshed Aula tokens persisted to config entry")
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    
+
     # Remove options_update_listener.
     hass.data[DOMAIN][entry.entry_id]["unsub_options_update_listener"]()
 

--- a/custom_components/aula_easyiq/__init__.py
+++ b/custom_components/aula_easyiq/__init__.py
@@ -82,7 +82,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception as err:  # pragma: no cover - best-effort persistence
             _LOGGER.warning("Failed to persist refreshed tokens: %s", err)
 
-    # Create the EasyIQ client
     client = EasyIQClient(
         mitid_username=mitid_username,
         auth_method=auth_method,
@@ -93,7 +92,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         token_update_callback=token_update_callback,
     )
 
-    # Validate / refresh tokens (or trigger reauth if not possible).
     try:
         login_ok = await hass.async_add_executor_job(client.login)
     except Exception as err:
@@ -106,10 +104,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "MitID re-authentication required. Please reconfigure EasyIQ."
         )
 
-    # Create the data update coordinator
     coordinator = EasyIQDataUpdateCoordinator(hass, client, entry)
 
-    # Perform initial data fetch
     try:
         await coordinator.async_config_entry_first_refresh()
     except Exception as err:

--- a/custom_components/aula_easyiq/aula_login_client/__init__.py
+++ b/custom_components/aula_easyiq/aula_login_client/__init__.py
@@ -1,0 +1,18 @@
+from .client import AulaLoginClient
+from .exceptions import (
+    AulaAuthenticationError,
+    MitIDError,
+    TokenExpiredError,
+    APIError
+)
+__version__ = "1.0.0"
+__author__ = "mchrdk"
+__description__ = "Aula platform authentication client with MitID integration"
+
+__all__ = [
+    "AulaLoginClient",
+    "AulaAuthenticationError",
+    "MitIDError",
+    "TokenExpiredError",
+    "APIError"
+]

--- a/custom_components/aula_easyiq/aula_login_client/client.py
+++ b/custom_components/aula_easyiq/aula_login_client/client.py
@@ -1,0 +1,1697 @@
+"""
+Aula Login Client - Main authentication client for Aula platform with MitID integration.
+
+This module contains the main AulaLoginClient class that handles the complete
+authentication flow including OAuth 2.0/OIDC, SAML, and MitID authentication.
+"""
+
+import requests
+import urllib.parse
+import base64
+import hashlib
+import secrets
+import re
+import json
+import time
+import binascii
+import uuid
+import os
+import logging
+from pathlib import Path
+from typing import Dict, Optional, Tuple, List
+from urllib.parse import parse_qs, urlparse, urljoin
+
+from bs4 import BeautifulSoup
+from Crypto import Random
+
+from .exceptions import (
+    AulaAuthenticationError,
+    MitIDError,
+    TokenExpiredError,
+    APIError,
+    ConfigurationError,
+    NetworkError,
+    SAMLError,
+    OAuthError,
+)
+
+# Import MitID BrowserClient from the local module
+try:
+    from .mitid_browserclient.BrowserClient import BrowserClient
+
+    MITID_AVAILABLE = True
+except ImportError as e:
+    MITID_AVAILABLE = False
+
+
+class AulaLoginClient:
+    """
+    Main client for Aula platform authentication with MitID integration.
+
+    This class handles the complete OAuth 2.0/OIDC + SAML + MitID authentication flow
+    that the Aula mobile application uses, including automated MitID authentication.
+
+    Features:
+    - Full authentication flow automation
+    - Token management and renewal
+    - API access testing
+    - Proxy support
+    - Comprehensive error handling
+
+    Example:
+        client = AulaLoginClient(
+            mitid_username="your_username",
+            auth_method="APP"
+        )
+
+        result = client.authenticate()
+        if result['success']:
+            tokens = result['tokens']
+    """
+
+    def __init__(
+        self,
+        mitid_username: str,
+        mitid_password: Optional[str] = None,
+        mitid_token: Optional[str] = None,
+        auth_method: str = "APP",
+        proxy: Optional[str] = None,
+        timeout: int = 30,
+        debug: bool = False,
+        verbose: bool = False,
+    ):
+        """
+        Initialize the Aula login client.
+
+        Args:
+            mitid_username: Your MitID username
+            mitid_password: Your MitID password (for TOKEN method)
+            auth_method: "APP" for MitID app, "TOKEN" for code token
+            proxy: Optional SOCKS5 proxy (format: "host:port")
+            timeout: Request timeout in seconds
+            debug: Enable debug logging
+            verbose: Enable verbose output (default: False)
+
+        Raises:
+            ConfigurationError: If MitID BrowserClient is not available
+        """
+        if not MITID_AVAILABLE:
+            raise ConfigurationError(
+                "MitID BrowserClient not found. Please install: pip install mitid-browserclient"
+            )
+
+        self.session = requests.Session()
+        self.mitid_username = mitid_username
+        self.mitid_password = mitid_password
+        self.mitid_token = mitid_token
+        self.auth_method = auth_method
+        self.timeout = timeout
+        self.debug = debug
+        self.verbose = verbose
+
+        # Initialize logger for Home Assistant integration
+        self.logger = logging.getLogger(__name__)
+
+        # Configure proxy if provided
+        if proxy:
+            self.session.proxies.update(
+                {"http": f"socks5://{proxy}", "https": f"socks5://{proxy}"}
+            )
+
+        # Mobile app user agent from MITM flows
+        self.session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (Linux; Android 14; sdk_gphone64_x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Mobile Safari/537.36",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate, br",
+                "Upgrade-Insecure-Requests": "1",
+                "sec-ch-ua": '"Google Chrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24"',
+                "sec-ch-ua-mobile": "?1",
+                "sec-ch-ua-platform": '"Android"',
+            }
+        )
+
+        # URLs from MITM analysis
+        self.auth_base_url = "https://login.aula.dk"
+        self.broker_url = "https://broker.unilogin.dk"
+        self.app_redirect_uri = "https://app-private.aula.dk"
+        self.app_api_base = "https://app-private.aula.dk/api/v22"
+
+        # OAuth configuration from source code
+        self.client_id_level_3 = "_99949a54b8b65423862aac1bf629599ed64231607a"
+        self.scope = "aula-sensitive"
+
+        # Session state
+        self.code_verifier = None
+        self.code_challenge = None
+        self.state = None
+        self.tokens = None
+        self.mitid_client = None  # Store MitID client for QR code access
+
+    def log(self, message: str, level: str = "INFO"):
+        """Enhanced logging using Home Assistant logging system"""
+        # Map string level to logging methods
+        level_map = {
+            "DEBUG": self.logger.debug,
+            "INFO": self.logger.info,
+            "WARN": self.logger.warning,
+            "WARNING": self.logger.warning,
+            "ERROR": self.logger.error,
+        }
+
+        # Get the appropriate logging method
+        log_method = level_map.get(level.upper(), self.logger.info)
+
+        # Apply verbose/debug filtering
+        if not self.verbose and level.upper() in ["DEBUG", "INFO"]:
+            return
+        if not self.debug and level.upper() == "DEBUG":
+            return
+
+        # Log the message
+        log_method(message)
+
+    def generate_pkce_parameters(self) -> Tuple[str, str]:
+        """Generate PKCE parameters for OAuth 2.0"""
+        code_verifier = (
+            base64.urlsafe_b64encode(secrets.token_bytes(32))
+            .decode("utf-8")
+            .rstrip("=")
+        )
+        challenge = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+        code_challenge = base64.urlsafe_b64encode(challenge).decode("utf-8").rstrip("=")
+        return code_verifier, code_challenge
+
+    def generate_state(self) -> str:
+        """Generate OAuth state parameter"""
+        return (
+            base64.urlsafe_b64encode(secrets.token_bytes(16))
+            .decode("utf-8")
+            .rstrip("=")
+        )
+
+    def step1_start_oauth_flow(self) -> str:
+        """Step 1: Start OAuth authorization flow"""
+        self.log("Starting OAuth 2.0 authorization flow")
+
+        try:
+            # Generate PKCE parameters
+            self.code_verifier, self.code_challenge = self.generate_pkce_parameters()
+            self.state = self.generate_state()
+
+            # Build authorization URL
+            auth_params = {
+                "response_type": "code",
+                "client_id": self.client_id_level_3,
+                "scope": self.scope,
+                "redirect_uri": self.app_redirect_uri,
+                "state": self.state,
+                "code_challenge": self.code_challenge,
+                "code_challenge_method": "S256",
+            }
+
+            auth_url = f"{self.auth_base_url}/simplesaml/module.php/oidc/authorize.php"
+            full_auth_url = f"{auth_url}?{urllib.parse.urlencode(auth_params)}"
+
+            self.log(
+                "Authorization URL generated, now visiting it to start the flow {full_auth_url}"
+            )
+
+            # Actually visit the OAuth authorization URL - this should redirect to SAML
+            oauth_response = self.session.get(
+                full_auth_url, allow_redirects=False, timeout=self.timeout
+            )
+            self.log(f"OAuth authorization response: {oauth_response.status_code}", "DEBUG")
+
+            if oauth_response.status_code in [301, 302, 303, 307, 308]:
+                # Follow the redirect to SAML
+                redirect_url = oauth_response.headers.get("Location")
+                self.log(f"OAuth redirecting to: {redirect_url[:100]}...")
+                return redirect_url
+            elif oauth_response.status_code == 200:
+                # Check if this page contains a SAML form or redirect
+                soup = BeautifulSoup(oauth_response.text, "html.parser")
+
+                # Look for SAML form
+                saml_form = soup.find("form")
+                if saml_form and saml_form.get("action"):
+                    action = saml_form.get("action")
+                    self.log(f"Found SAML form with action: {action}")
+                    return action
+
+                # Look for meta refresh or JavaScript redirect
+                meta_refresh = soup.find("meta", {"http-equiv": "refresh"})
+                if meta_refresh:
+                    content = meta_refresh.get("content", "")
+                    if "url=" in content.lower():
+                        url = content.split("url=", 1)[1]
+                        self.log(f"Found meta refresh redirect: {url}")
+                        return url
+
+                raise OAuthError(
+                    "OAuth authorization endpoint returned 200 but no redirect found"
+                )
+            else:
+                raise OAuthError(
+                    f"Unexpected OAuth authorization response: {oauth_response.status_code}"
+                )
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during OAuth flow: {str(e)}")
+
+    def step3_follow_redirect_chain(self, start_url: str) -> Dict:
+        """Step 3: Follow the redirect chain to MitID"""
+        self.log("Following redirect chain to MitID")
+
+        current_url = start_url
+        redirect_count = 0
+        max_redirects = 10
+
+        try:
+            while redirect_count < max_redirects:
+                response = self.session.get(
+                    current_url, allow_redirects=False, timeout=self.timeout
+                )
+                self.log(
+                    f"Redirect {redirect_count + 1}: {response.status_code} -> {current_url[:80]}..."
+                )
+
+                if response.status_code == 200:
+                    # We've reached a page that needs interaction
+                    soup = BeautifulSoup(response.text, "html.parser")
+
+                    # Check what kind of page this is
+                    if "broker.unilogin.dk" in response.url:
+                        self.log("Reached UniLogin broker - looking for IdP selection")
+                        return self._handle_broker_page(soup, response)
+
+                    elif "mitid.dk" in response.url or "nemlog-in" in response.url:
+                        self.log("Reached MitID page")
+
+                        # Extract verification token
+                        token_input = soup.find(
+                            "input", {"name": "__RequestVerificationToken"}
+                        )
+                        if not token_input:
+                            raise SAMLError(
+                                "Could not find RequestVerificationToken on MitID page"
+                            )
+
+                        verification_token = token_input["value"]
+                        self.log(f"Found RequestVerificationToken")
+
+                        return {
+                            "verification_token": verification_token,
+                            "mitid_url": response.url,
+                            "session_cookies": dict(self.session.cookies),
+                        }
+
+                    else:
+                        raise SAMLError(f"Unexpected page reached: {response.url}")
+
+                elif response.status_code in [301, 302, 303, 307, 308]:
+                    if "Location" not in response.headers:
+                        raise SAMLError(f"Redirect response missing Location header")
+
+                    current_url = urljoin(current_url, response.headers["Location"])
+                    redirect_count += 1
+
+                else:
+                    raise SAMLError(f"Unexpected status code: {response.status_code}")
+
+            raise SAMLError(f"Too many redirects ({max_redirects})")
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during redirect chain: {str(e)}")
+
+    def _handle_broker_page(self, soup, response) -> Dict:
+        """Handle the broker page for IdP selection"""
+        # Look for MitID/NemLogin selection form or button
+        forms = soup.find_all("form")
+        self.log(f"Found {len(forms)} forms on the page")
+
+        # Try standard form submission for NemLogin/MitID
+        main_form = soup.find("form")
+        if main_form:
+            action = main_form.get("action", "")
+            if action:
+                self.log(f"Submitting form to: {action}")
+
+                # Common patterns for MitID selection
+                form_data = {}
+
+                # Try various common parameter names for IdP selection
+                idp_selectors = ["selectedIdp", "idp", "authMethod", "provider"]
+                idp_values = ["nemlogin3", "mitid", "MitID", "nemlogin"]
+
+                # Look for existing hidden inputs
+                for inp in main_form.find_all("input"):
+                    name = inp.get("name")
+                    value = inp.get("value", "")
+                    if name:
+                        form_data[name] = value
+
+                # Try to set IdP selection
+                for selector in idp_selectors:
+                    for value in idp_values:
+                        test_data = form_data.copy()
+                        test_data[selector] = value
+
+                        self.log(f"Trying form submission with {selector}={value}")
+
+                        post_response = self.session.post(
+                            action,
+                            data=test_data,
+                            allow_redirects=False,
+                            timeout=self.timeout,
+                        )
+                        self.log(f"Form submission result: {post_response.status_code}", "DEBUG")
+
+                        if post_response.status_code in [301, 302, 303, 307, 308]:
+                            if "Location" in post_response.headers:
+                                current_url = post_response.headers["Location"]
+                                self.log(
+                                    f"Form submission redirected to: {current_url[:100]}..."
+                                )
+                                # Continue following redirects from this new URL
+                                return self.step3_follow_redirect_chain(current_url)
+
+                raise SAMLError("Could not find working IdP selection method")
+
+        raise SAMLError("No usable form found on broker page")
+
+    def step4_mitid_authentication(self, verification_token: str) -> str:
+        """Step 4: Perform MitID authentication"""
+        self.log(f"Starting MitID authentication (method: {self.auth_method})")
+
+        try:
+            # Initialize MitID authentication
+            post_url = "https://nemlog-in.mitid.dk/login/mitid/initialize"
+            post_headers = {
+                "accept": "*/*",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "accept-language": "en-US,en;q=0.9,da;q=0.8",
+                "cache-control": "no-cache",
+                "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+                "origin": "https://nemlog-in.mitid.dk",
+                "pragma": "no-cache",
+                "referer": "https://nemlog-in.mitid.dk/login/mitid",
+                "x-requested-with": "XMLHttpRequest",
+            }
+
+            post_data = {"__RequestVerificationToken": verification_token}
+
+            resp_init = self.session.post(
+                post_url, headers=post_headers, data=post_data, timeout=self.timeout
+            )
+            resp_init_json = resp_init.json()
+
+            if isinstance(resp_init_json, str):
+                resp_init_json = json.loads(resp_init_json)
+
+            aux_value = resp_init_json.get("Aux")
+            if not aux_value:
+                raise MitIDError("No Aux value in MitID initialization response")
+
+            aux = json.loads(base64.b64decode(aux_value).decode())
+
+            # Use MitID BrowserClient for authentication
+            authorization_code = self._get_mitid_authentication_code(aux)
+            self.log(f"MitID authentication code obtained")
+
+            # Clear MitID client to prevent QR codes from showing up again in UI
+            self.mitid_client = None
+
+            return authorization_code
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during MitID authentication: {str(e)}")
+        except (json.JSONDecodeError, KeyError) as e:
+            raise MitIDError(f"Invalid MitID response format: {str(e)}")
+
+    def _get_mitid_authentication_code(self, aux: Dict) -> str:
+        """Use MitID BrowserClient to get authentication code"""
+        try:
+            client_hash = binascii.hexlify(
+                base64.b64decode(aux["coreClient"]["checksum"])
+            ).decode("ascii")
+            authentication_session_id = aux["parameters"]["authenticationSessionId"]
+
+            self.mitid_client = BrowserClient(
+                client_hash, authentication_session_id, self.session
+            )
+            available_authenticators = (
+                self.mitid_client.identify_as_user_and_get_available_authenticators(
+                    self.mitid_username
+                )
+            )
+
+            self.log(
+                f"Chosen method is {self.auth_method}, Available authenticators: {available_authenticators}"
+            )
+
+            if self.auth_method == "TOKEN" and "TOKEN" in available_authenticators:
+                self.log(f"Ok starting token authentication")
+                if not self.mitid_password:
+                    self.mitid_password = input(
+                        "Please input your MitID password: "
+                    ).strip()
+                if not self.mitid_token:
+                    self.mitid_token = input(
+                        "Please input the 6 digits from your code token: "
+                    ).strip()
+                self.log(
+                    f"Starting token authentication with {self.mitid_password} and {self.mitid_token}"
+                )
+                self.mitid_client.authenticate_with_token(self.mitid_token)
+                self.mitid_client.authenticate_with_password(self.mitid_password)
+            elif self.auth_method == "APP" and "APP" in available_authenticators:
+                self.mitid_client.authenticate_with_app()
+            else:
+                raise MitIDError(
+                    f"Authentication method {self.auth_method} not available"
+                )
+
+            authorization_code = (
+                self.mitid_client.finalize_authentication_and_get_authorization_code()
+            )
+            return authorization_code
+
+        except Exception as e:
+            raise MitIDError(f"MitID authentication failed: {str(e)}")
+
+    def step5_complete_mitid_flow(
+        self, verification_token: str, authorization_code: str
+    ) -> Dict:
+        """Step 5: Complete MitID authentication and get SAML response"""
+        self.log("Completing MitID authentication flow")
+
+        try:
+            session_storage_active_session_uuid = self.session.cookies.get(
+                "SessionUuid", ""
+            )
+            session_storage_active_challenge = self.session.cookies.get("Challenge", "")
+
+            params = {
+                "__RequestVerificationToken": verification_token,
+                "NewCulture": "",
+                "MitIDUseConfirmed": "True",
+                "MitIDAuthCode": authorization_code,
+                "MitIDAuthenticationCancelled": "",
+                "MitIDCoreClientError": "",
+                "SessionStorageActiveSessionUuid": session_storage_active_session_uuid,
+                "SessionStorageActiveChallenge": session_storage_active_challenge,
+            }
+
+            self.log(
+                f"Submitting MitID completion data to: https://nemlog-in.mitid.dk/login/mitid"
+            )
+            request = self.session.post(
+                "https://nemlog-in.mitid.dk/login/mitid",
+                data=params,
+                timeout=self.timeout,
+            )
+
+            self.log(f"MitID completion response: {request.status_code}", "DEBUG")
+            self.log(f"Final URL: {request.url}", "DEBUG")
+
+            soup = BeautifulSoup(request.text, features="html.parser")
+
+            # Handle multiple identity options if present
+            if request.url == "https://nemlog-in.mitid.dk/loginoption":
+                self.log("Multiple identity options detected, choosing...")
+                request, soup = self._choose_between_multiple_identities(request, soup)
+                self.log(
+                    f"After identity choice: {request.status_code} -> {request.url}"
+                )
+
+            # Extract SAML response
+            relay_state_input = soup.find("input", {"name": "RelayState"})
+            saml_response_input = soup.find("input", {"name": "SAMLResponse"})
+
+            if not relay_state_input:
+                raise SAMLError(
+                    "Could not find RelayState in MitID completion response"
+                )
+
+            if not saml_response_input:
+                raise SAMLError(
+                    "Could not find SAMLResponse in MitID completion response"
+                )
+
+            relay_state = relay_state_input.get("value")
+            saml_response = saml_response_input.get("value")
+
+            self.log(f" SAML data extracted successfully")
+
+            return {
+                "relay_state": relay_state,
+                "saml_response": saml_response,
+                "completion_url": request.url,
+            }
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during MitID completion: {str(e)}")
+
+    def _choose_between_multiple_identities(self, request, soup):
+        """Handle multiple identity selection"""
+        data = {}
+        for soup_input in soup.form.select("input"):
+            try:
+                name = soup_input["name"]
+                data[name] = soup_input.get("value", "")
+            except KeyError:
+                try:
+                    data[soup_input["id"]] = soup_input.get("value", "")
+                except KeyError:
+                    self.log(
+                        f"Could not store value for input field {soup_input}", "WARN"
+                    )
+
+        # Update SessionStorage values from cookies (they might have changed)
+        session_uuid = self.session.cookies.get("SessionUuid", "")
+        challenge = self.session.cookies.get("Challenge", "")
+        if session_uuid:
+            data["SessionStorageActiveSessionUuid"] = session_uuid
+        if challenge:
+            data["SessionStorageActiveChallenge"] = challenge
+
+        login_options = soup.select("a.list-link")
+        identities = []
+        identity_names = []
+        for i, login_option in enumerate(login_options):
+            identity_name = login_option.select_one("div.list-link-text").string
+            identities.append(i + 1)
+            identity_names.append(identity_name)
+
+        # Store the available identities for external handling
+        self.available_identities = identity_names
+
+        # If identity_selector callback is provided, use it; otherwise use input()
+        if hasattr(self, "identity_selector") and self.identity_selector:
+            identity = self.identity_selector(identity_names)
+        else:
+            self.log("You can choose between different identities:", "INFO")
+            for i, name in enumerate(identity_names):
+                self.log(f"{i+1}: {name}", "INFO")
+            identity = 1  # input("Enter the identity you want to use: ").strip()
+
+        if int(identity) in identities:
+            selected_login_option = login_options[int(identity) - 1]
+            selected_option = selected_login_option["data-loginoptions"]
+            data["ChosenOptionJson"] = selected_option
+        else:
+            raise MitIDError("Identity not in list of identities")
+
+        # Need to follow redirects and use proper headers
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Referer": request.url,
+        }
+        request = self.session.post(
+            request.url,
+            data=data,
+            headers=headers,
+            timeout=self.timeout,
+            allow_redirects=True,
+        )
+        soup = BeautifulSoup(request.text, features="html.parser")
+        return request, soup
+
+    def step6_saml_broker_flow(self, saml_data: Dict) -> Dict:
+        """Step 6: Complete SAML broker authentication"""
+        self.log("Processing SAML broker flow")
+
+        try:
+            # Post SAML response to broker
+            saml_post_headers = {
+                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "accept-language": "en-US,en;q=0.9,da;q=0.8",
+                "cache-control": "max-age=0",
+                "content-type": "application/x-www-form-urlencoded",
+                "origin": "https://nemlog-in.mitid.dk",
+                "referer": "https://nemlog-in.mitid.dk/login/mitid",
+                "sec-fetch-dest": "document",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-site": "cross-site",
+                "sec-fetch-user": "?1",
+                "upgrade-insecure-requests": "1",
+            }
+
+            params = {
+                "RelayState": saml_data["relay_state"],
+                "SAMLResponse": saml_data["saml_response"],
+            }
+
+            # Add cookies to headers
+            cookie_header = "; ".join(
+                [f"{c.name}={c.value}" for c in self.session.cookies]
+            )
+            if cookie_header:
+                saml_post_headers["cookie"] = cookie_header
+
+            # Post to broker endpoint
+            broker_response = self.session.post(
+                "https://broker.unilogin.dk/auth/realms/broker/broker/nemlogin3/endpoint",
+                data=params,
+                headers=saml_post_headers,
+                allow_redirects=False,
+                timeout=self.timeout,
+            )
+
+            if "Location" not in broker_response.headers:
+                raise SAMLError("No redirect from broker endpoint")
+
+            # Follow redirect chain through broker
+            action_url = broker_response.headers["Location"]
+            final_request = self.session.get(action_url, timeout=self.timeout)
+
+            return self._process_broker_response(final_request)
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during SAML broker flow: {str(e)}")
+
+    def _process_broker_response(self, response) -> Dict:
+        """Process broker response and extract session parameters"""
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Extract session parameters from URL or form
+        parsed_url = urlparse(response.url)
+        query_params = parse_qs(parsed_url.query)
+
+        session_code = query_params.get("session_code", [""])[0]
+        execution = query_params.get("execution", [""])[0]
+        client_id = query_params.get("client_id", [""])[0]
+        tab_id = query_params.get("tab_id", [""])[0]
+
+        # Fallback to form extraction if not in URL
+        if not session_code or not execution:
+            form = soup.find("form")
+            if form:
+                form_action = form.get("action", "")
+                if form_action:
+                    parsed_form_url = urlparse(form_action)
+                    form_query_params = parse_qs(parsed_form_url.query)
+                    session_code = form_query_params.get("session_code", [""])[0]
+                    execution = form_query_params.get("execution", [""])[0]
+                    client_id = form_query_params.get("client_id", [""])[0]
+                    tab_id = form_query_params.get("tab_id", [""])[0]
+
+        # Complete post-broker-login
+        self.log(f"Broker response URL for param extraction: {response.url}", "DEBUG")
+        self.log(
+            f"Broker params - session_code: {session_code}, execution: {execution}, client_id: {client_id}, tab_id: {tab_id}", "DEBUG"
+        )
+
+        # Extract form data to submit
+        form = soup.find("form")
+        form_data = {}
+
+        # Log the full page to understand what we're dealing with
+        self.log(f"Broker page HTML (first 3000 chars): {response.text[:3000]}", "DEBUG")
+
+        if form:
+            form_action = form.get("action", "")
+            self.log(f"Found form action: {form_action}")
+            inputs = form.find_all("input")
+            for inp in inputs:
+                name = inp.get("name")
+                value = inp.get("value", "")
+                if name:
+                    form_data[name] = value
+                self.log(
+                    f"  Form input: name={name}, type={inp.get('type')}, value={value[:50] if value else 'empty'}"
+                )
+
+            # Handle role selection if present (Elev vs Kontakt)
+            if "selected-aktoer" in form_data:
+                self.log(
+                    "Found role selection form (selected-aktoer), setting to 'KONTAKT'"
+                )
+                form_data["selected-aktoer"] = "KONTAKT"
+
+            # Also look for select elements and buttons that might have values
+            selects = form.find_all("select")
+            for sel in selects:
+                self.log(f"  Select: name={sel.get('name')}")
+                options = sel.find_all("option")
+                for opt in options:
+                    self.log(
+                        f"    Option: value={opt.get('value')}, text={opt.text[:50] if opt.text else 'empty'}"
+                    )
+
+            # Look for radio buttons or other input types
+            buttons = form.find_all("button")
+            for btn in buttons:
+                self.log(
+                    f"  Button: type={btn.get('type')}, name={btn.get('name')}, value={btn.get('value')}"
+                )
+
+            # Use the form action URL if available (it has all the proper params)
+            if form_action and form_action.startswith("http"):
+                post_broker_url = form_action
+            elif form_action:
+                post_broker_url = f"https://broker.unilogin.dk{form_action}"
+            else:
+                post_broker_url = f"https://broker.unilogin.dk/auth/realms/broker/login-actions/post-broker-login?session_code={session_code}&execution={execution}&client_id={client_id}&tab_id={tab_id}"
+        else:
+            self.log("No form found in broker response")
+            post_broker_url = f"https://broker.unilogin.dk/auth/realms/broker/login-actions/post-broker-login?session_code={session_code}&execution={execution}&client_id={client_id}&tab_id={tab_id}"
+
+        if not session_code or not execution:
+            self.log(f"Warning: Missing broker params. Response URL: {response.url}")
+            self.log(f"Response body (first 1000 chars): {response.text[:1000]}")
+
+        self.log(f"Post-broker URL: {post_broker_url}", "DEBUG")
+        self.log(f"Post-broker form data: {form_data}", "DEBUG")
+
+        post_broker_headers = {
+            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+            "content-type": "application/x-www-form-urlencoded",
+            "sec-fetch-dest": "document",
+            "sec-fetch-mode": "navigate",
+            "sec-fetch-site": "same-origin",
+            "upgrade-insecure-requests": "1",
+        }
+
+        # Add cookies
+        cookie_header = "; ".join([f"{c.name}={c.value}" for c in self.session.cookies])
+        if cookie_header:
+            post_broker_headers["cookie"] = cookie_header
+
+        post_broker_response = self.session.post(
+            post_broker_url,
+            headers=post_broker_headers,
+            data=form_data,
+            allow_redirects=False,
+            timeout=self.timeout,
+        )
+
+        self.log(f"Post-broker response status: {post_broker_response.status_code}", "DEBUG")
+        self.log(f"Post-broker response headers: {dict(post_broker_response.headers)}", "DEBUG")
+        if post_broker_response.status_code != 302:
+            self.log(f"Post-broker response body: {post_broker_response.text}", "DEBUG")
+
+        # Handle intermediate confirmation page (200 OK)
+        if post_broker_response.status_code == 200:
+            soup = BeautifulSoup(post_broker_response.text, "html.parser")
+            confirmation_button = soup.find("button", {"id": "confirmation-button"})
+
+            if confirmation_button:
+                self.log(
+                    "Found intermediate confirmation page (UniLogin success), submitting..."
+                )
+                form = confirmation_button.find_parent("form")
+                if form:
+                    action = form.get("action")
+                    if action:
+                        if not action.startswith("http"):
+                            action = urljoin(post_broker_response.url, action)
+
+                        self.log(f"Submitting confirmation form to: {action}")
+
+                        conf_data = {}
+                        for inp in form.find_all("input"):
+                            if inp.get("name"):
+                                conf_data[inp.get("name")] = inp.get("value", "")
+
+                        # Update cookies for the next request
+                        cookie_header = "; ".join(
+                            [f"{c.name}={c.value}" for c in self.session.cookies]
+                        )
+                        if cookie_header:
+                            post_broker_headers["cookie"] = cookie_header
+
+                        post_broker_response = self.session.post(
+                            action,
+                            headers=post_broker_headers,
+                            data=conf_data,
+                            allow_redirects=False,
+                            timeout=self.timeout,
+                        )
+
+                        self.log(
+                            f"Confirmation response status: {post_broker_response.status_code}", "DEBUG"
+                        )
+                        if post_broker_response.status_code != 302:
+                            self.log(
+                                f"Confirmation response body: {post_broker_response.text}", "DEBUG"
+                            )
+
+        if "Location" not in post_broker_response.headers:
+            raise SAMLError(
+                f"No redirect from post-broker-login (status={post_broker_response.status_code})"
+            )
+
+        # Follow final redirect
+        after_post_broker_url = post_broker_response.headers["Location"]
+        after_response = self.session.get(after_post_broker_url, timeout=self.timeout)
+
+        # Extract final SAML response for Aula
+        after_soup = BeautifulSoup(after_response.text, "html.parser")
+
+        self.log(f"Final broker response URL: {after_response.url}", "DEBUG")
+        self.log(f"Final broker response status: {after_response.status_code}", "DEBUG")
+
+        saml_form = after_soup.find("form")
+
+        if not saml_form:
+            raise SAMLError("No SAML form found in broker response")
+
+        self.log(f" Found SAML form with action: {saml_form.get('action', 'N/A')}")
+
+        saml_response_input = saml_form.find("input", {"name": "SAMLResponse"})
+        relay_state_input = saml_form.find("input", {"name": "RelayState"})
+
+        if not saml_response_input:
+            raise SAMLError("Could not find SAMLResponse - this is critical")
+
+        # RelayState might be optional in some flows
+        relay_state_value = relay_state_input.get("value") if relay_state_input else ""
+
+        if not relay_state_input:
+            self.log("  RelayState not found - this might be OK for Level 3 auth flow")
+
+        return {
+            "final_saml_response": saml_response_input.get("value"),
+            "final_relay_state": relay_state_value,
+            "form_action": saml_form.get("action", ""),
+        }
+
+    def step7_complete_aula_login(self, saml_data: Dict) -> str:
+        """Step 7: Complete Aula login with SAML response"""
+        self.log("Completing Aula login with SAML response")
+
+        try:
+            aula_saml_headers = {
+                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                "content-type": "application/x-www-form-urlencoded",
+                "origin": "null",
+                "sec-fetch-dest": "document",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-site": "cross-site",
+                "upgrade-insecure-requests": "1",
+            }
+
+            # Add Aula cookies
+            aula_cookie_header = "; ".join(
+                [
+                    f"{c.name}={c.value}"
+                    for c in self.session.cookies
+                    if "aula.dk" in c.domain or c.domain == ""
+                ]
+            )
+            if aula_cookie_header:
+                aula_saml_headers["cookie"] = aula_cookie_header
+
+            aula_saml_data = {
+                "SAMLResponse": saml_data["final_saml_response"],
+                "RelayState": saml_data["final_relay_state"],
+            }
+
+            # Use the form action from the broker response instead of hardcoding
+            saml_endpoint = saml_data.get(
+                "form_action",
+                "https://login.aula.dk/simplesaml/module.php/saml/sp/saml2-acs.php/uni-sp",
+            )
+            self.log(f"Submitting SAML response to: {saml_endpoint}")
+
+            # Post to Aula SAML endpoint
+            aula_response = self.session.post(
+                saml_endpoint,
+                headers=aula_saml_headers,
+                data=aula_saml_data,
+                allow_redirects=False,
+                timeout=self.timeout,
+            )
+
+            self.log(f"SAML response status: {aula_response.status_code}", "DEBUG")
+
+            if "Location" not in aula_response.headers:
+                raise OAuthError("No redirect from Aula SAML endpoint")
+
+            # Follow the redirect chain manually to capture all steps
+            return self._follow_oauth_callback_redirects(
+                aula_response.headers["Location"]
+            )
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during Aula login completion: {str(e)}")
+
+    def _follow_oauth_callback_redirects(self, start_url: str) -> str:
+        """Follow redirects to find the OAuth callback URL"""
+        redirect_url = start_url
+        redirect_count = 0
+        max_redirects = 10
+
+        while redirect_count < max_redirects:
+            redirect_count += 1
+            self.log(f"Following redirect #{redirect_count}: {redirect_url[:100]}...")
+
+            redirect_response = self.session.get(
+                redirect_url, allow_redirects=False, timeout=self.timeout
+            )
+            self.log(f"Redirect response status: {redirect_response.status_code}", "DEBUG")
+
+            # Check if this is the OAuth callback we're looking for
+            if (
+                self.app_redirect_uri in redirect_response.url
+                and "code=" in redirect_response.url
+            ):
+                self.log(f" Found OAuth callback URL: {redirect_response.url}")
+                return redirect_response.url
+
+            # Check if this is the OAuth callback in Location header
+            if "Location" in redirect_response.headers:
+                location = redirect_response.headers["Location"]
+                if self.app_redirect_uri in location and "code=" in location:
+                    self.log(f" Found OAuth callback in Location header: {location}")
+                    return location
+
+            # If it's a 200 response, check the final URL
+            if redirect_response.status_code == 200:
+                final_url = redirect_response.url
+                self.log(f"Final destination (200): {final_url}")
+
+                # Check if we got an OAuth callback URL
+                if self.app_redirect_uri in final_url and "code=" in final_url:
+                    return final_url
+                else:
+                    raise OAuthError(
+                        f"Did not receive OAuth callback URL. Final URL: {final_url}"
+                    )
+
+            # If it's a redirect, follow it
+            elif redirect_response.status_code in [301, 302, 303, 307, 308]:
+                if "Location" not in redirect_response.headers:
+                    raise OAuthError(
+                        f"Redirect response missing Location header at step {redirect_count}"
+                    )
+
+                redirect_url = redirect_response.headers["Location"]
+
+                # Handle relative URLs
+                if redirect_url.startswith("/"):
+                    base_url = f"{urlparse(redirect_response.url).scheme}://{urlparse(redirect_response.url).netloc}"
+                    redirect_url = urljoin(base_url, redirect_url)
+            else:
+                raise OAuthError(
+                    f"Unexpected status code {redirect_response.status_code} at redirect step {redirect_count}"
+                )
+
+        raise OAuthError(
+            f"Too many redirects ({max_redirects}) without finding OAuth callback"
+        )
+
+    def step8_exchange_oauth_code(self, callback_url: str) -> Dict:
+        """Step 8: Exchange OAuth authorization code for tokens"""
+        self.log("Exchanging OAuth authorization code for tokens")
+
+        try:
+            # Parse callback URL
+            parsed_url = urlparse(callback_url)
+            query_params = parse_qs(parsed_url.query)
+
+            if "code" not in query_params:
+                raise OAuthError("No authorization code in callback URL")
+
+            auth_code = query_params["code"][0]
+
+            # Verify state parameter
+            if "state" in query_params:
+                returned_state = query_params["state"][0]
+                if returned_state != self.state:
+                    raise OAuthError("State parameter mismatch")
+
+            # Exchange code for tokens
+            token_url = f"{self.auth_base_url}/simplesaml/module.php/oidc/token.php"
+
+            token_data = {
+                "grant_type": "authorization_code",
+                "code": auth_code,
+                "client_id": self.client_id_level_3,
+                "redirect_uri": self.app_redirect_uri,
+                "code_verifier": self.code_verifier,
+            }
+
+            headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            }
+
+            response = self.session.post(
+                token_url, data=token_data, headers=headers, timeout=self.timeout
+            )
+
+            if response.status_code != 200:
+                raise OAuthError(
+                    f"Token exchange failed: {response.status_code} - {response.text}"
+                )
+
+            tokens = response.json()
+
+            # Calculate expires_at timestamp for persistence
+            if "expires_in" in tokens:
+                tokens["expires_at"] = time.time() + tokens["expires_in"]
+
+            self.tokens = tokens
+
+            self.log("Token exchange successful!")
+            self.log(
+                f"Access token expires in: {tokens.get('expires_in', 'Unknown')} seconds"
+            )
+
+            return tokens
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during token exchange: {str(e)}")
+        except json.JSONDecodeError as e:
+            raise OAuthError(f"Invalid token response format: {str(e)}")
+
+    def step9_test_api_access(self) -> Dict:
+        """Step 9: Test API access with obtained tokens"""
+        self.log("Testing Aula API access")
+
+        if not self.tokens or "access_token" not in self.tokens:
+            raise APIError("No access token available")
+
+        try:
+            # Based on HAR file analysis - actual v22 API endpoints with correct parameters
+            v22_api_base = "https://www.aula.dk/api/v22/"
+
+            # Generate a device ID similar to what the app uses
+            device_id = f"Droid-private-{str(uuid.uuid4())}"
+
+            test_endpoints = [
+                # Core configuration endpoints (no auth needed)
+                (
+                    "centralConfiguration.getLoginImportantInformation",
+                    "GET",
+                    {"platform": "android-private"},
+                ),
+                # Profile endpoints (main user data) - these need access_token
+                (
+                    "profiles.getProfileTypesByLogin",
+                    "GET",
+                    {"access_token": self.tokens["access_token"]},
+                ),
+                (
+                    "profiles.getprofilesbylogin",
+                    "GET",
+                    {
+                        "portalRoles[]": "guardian",
+                        "access_token": self.tokens["access_token"],
+                    },
+                ),
+            ]
+
+            results = {}
+            api_headers = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "User-Agent": self.session.headers["User-Agent"],
+            }
+
+            for method_name, http_method, params in test_endpoints:
+                # Build URL with method parameter
+                url_params = {"method": method_name}
+                url_params.update(params)
+
+                # Convert params to query string
+                param_string = "&".join([f"{k}={v}" for k, v in url_params.items()])
+                url = f"{v22_api_base}?{param_string}"
+
+                try:
+                    self.log(f"Testing v22 API method: {method_name}")
+
+                    if http_method == "GET":
+                        response = self.session.get(
+                            url, headers=api_headers, timeout=self.timeout
+                        )
+                    elif http_method == "POST":
+                        response = self.session.post(
+                            url,
+                            headers=api_headers,
+                            json=params.get("data", {}),
+                            timeout=self.timeout,
+                        )
+                    else:
+                        continue
+
+                    results[method_name] = {
+                        "status_code": response.status_code,
+                        "success": response.status_code == 200,
+                        "url": url,
+                        "method": http_method,
+                    }
+
+                    if response.status_code == 200:
+                        try:
+                            data = response.json()
+                            results[method_name]["data"] = data
+                            self.log(f" {method_name}: Success - response received")
+                        except:
+                            results[method_name]["data"] = response.text[:200]
+                            self.log(f" {method_name}: Success - non-JSON response")
+                    else:
+                        results[method_name]["error"] = f"HTTP {response.status_code}"
+                        self.log(f"  {method_name}: {response.status_code}")
+
+                except Exception as e:
+                    self.log(f" {method_name}: Exception - {str(e)}")
+                    results[method_name] = {
+                        "success": False,
+                        "error": str(e),
+                        "url": url,
+                    }
+
+            # Check if any endpoint worked
+            successful_endpoints = [
+                ep for ep, result in results.items() if result.get("success")
+            ]
+
+            if successful_endpoints:
+                self.log(
+                    f"✅ API access working! Successful endpoints: {successful_endpoints}"
+                )
+                return {
+                    "success": True,
+                    "results": results,
+                    "working_endpoints": successful_endpoints,
+                }
+            else:
+                self.log("  No API endpoints worked, but authentication was successful")
+                return {
+                    "success": False,
+                    "results": results,
+                    "message": "Authentication successful but API access limited",
+                }
+
+        except requests.RequestException as e:
+            raise NetworkError(f"Network error during API testing: {str(e)}")
+
+    def check_token_expiration(self) -> Dict:
+        """Check if the access token is about to expire"""
+        if not self.tokens or "access_token" not in self.tokens:
+            return {"valid": False, "reason": "No access token available"}
+
+        try:
+            # Decode JWT token to check expiration
+            token_parts = self.tokens["access_token"].split(".")
+            if len(token_parts) >= 2:
+                payload = token_parts[1]
+                padding = 4 - (len(payload) % 4)
+                if padding != 4:
+                    payload += "=" * padding
+                decoded = base64.urlsafe_b64decode(payload)
+                token_data = json.loads(decoded)
+
+                exp_timestamp = token_data.get("exp")
+                if exp_timestamp:
+                    current_time = time.time()
+                    expires_in = exp_timestamp - current_time
+
+                    # Consider token expired if less than 5 minutes remaining
+                    if expires_in < 300:  # 5 minutes
+                        return {
+                            "valid": False,
+                            "reason": f"Token expires in {int(expires_in)} seconds",
+                            "expires_in": expires_in,
+                        }
+                    else:
+                        return {
+                            "valid": True,
+                            "expires_in": expires_in,
+                            "expires_at": exp_timestamp,
+                        }
+
+        except Exception as e:
+            self.log(f"Error checking token expiration: {str(e)}")
+
+        # If we can't decode the token, assume it's invalid
+        return {"valid": False, "reason": "Unable to decode token"}
+
+    def renew_access_token(self) -> bool:
+        """Renew the access token using the refresh token"""
+        if not self.tokens or "refresh_token" not in self.tokens:
+            self.log("No refresh token available for renewal", "ERROR")
+            return False
+
+        try:
+            self.log("Attempting to renew access token using refresh token")
+
+            token_url = f"{self.auth_base_url}/simplesaml/module.php/oidc/token.php"
+
+            token_data = {
+                "grant_type": "refresh_token",
+                "refresh_token": self.tokens["refresh_token"],
+                "client_id": self.client_id_level_3,
+            }
+
+            token_headers = {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+                "User-Agent": self.session.headers["User-Agent"],
+            }
+
+            response = self.session.post(
+                token_url, data=token_data, headers=token_headers, timeout=self.timeout
+            )
+
+            if response.status_code == 200:
+                token_response = response.json()
+
+                # Update tokens
+                self.tokens["access_token"] = token_response["access_token"]
+                if "refresh_token" in token_response:
+                    self.tokens["refresh_token"] = token_response["refresh_token"]
+                if "expires_in" in token_response:
+                    self.tokens["expires_in"] = token_response["expires_in"]
+
+                self.log(
+                    f" Token renewed successfully! Expires in: {token_response.get('expires_in', 'unknown')} seconds"
+                )
+                return True
+            else:
+                self.log(
+                    f" Token renewal failed: {response.status_code} - {response.text}",
+                    "ERROR",
+                )
+                return False
+
+        except Exception as e:
+            self.log(f" Token renewal exception: {str(e)}", "ERROR")
+            return False
+
+    def test_token_validity(self) -> bool:
+        """Test if the current token is valid by making a simple API call"""
+        try:
+            # Test with a simple API call
+            test_url = f"https://www.aula.dk/api/v22/?method=profiles.getProfileContext&portalrole=guardian"
+
+            headers = {
+                "Accept": "application/json",
+                "User-Agent": self.session.headers["User-Agent"],
+            }
+
+            # Add access token if we have one
+            if self.tokens and "access_token" in self.tokens:
+                test_url += f"&access_token={self.tokens['access_token']}"
+
+                response = self.session.get(test_url, headers=headers, timeout=10)
+
+            if response.status_code == 200:
+                self.log("Token validation successful")
+                return True
+            elif response.status_code in [401, 403, 500]:
+                self.log(
+                    f"Token validation failed: {response.status_code} - Token invalid/expired"
+                )
+                return False
+            else:
+                self.log(f"Token validation uncertain: {response.status_code}")
+                return True  # Assume valid for non-auth errors
+
+        except Exception as e:
+            self.log(f"Token validation exception: {str(e)}")
+            return False
+
+    def authenticate(self) -> Dict:
+        """
+        Execute the complete authentication flow.
+
+        Returns:
+            Dict containing success status, tokens, and profile data
+
+        Raises:
+            AulaAuthenticationError: If authentication fails at any step
+        """
+        self.log("=" * 60)
+        self.log("STARTING INTEGRATED AULA LOGIN FLOW")
+        self.log("=" * 60)
+
+        try:
+            # Step 1: Start OAuth flow (this will redirect to SAML)
+            saml_redirect_url = self.step1_start_oauth_flow()
+
+            # Step 2: Follow the OAuth→SAML redirect chain to MitID
+            mitid_data = self.step3_follow_redirect_chain(saml_redirect_url)
+
+            # Step 3: MitID authentication
+            auth_code = self.step4_mitid_authentication(
+                mitid_data["verification_token"]
+            )
+
+            # Step 4: Complete MitID flow
+            saml_response_data = self.step5_complete_mitid_flow(
+                mitid_data["verification_token"], auth_code
+            )
+
+            # Step 5: SAML broker flow
+            broker_data = self.step6_saml_broker_flow(saml_response_data)
+
+            # Step 6: Complete Aula login (this should now redirect back to OAuth)
+            callback_url = self.step7_complete_aula_login(broker_data)
+
+            # Step 7: Exchange OAuth code
+            tokens = self.step8_exchange_oauth_code(callback_url)
+
+            # Step 8: Test API access
+            profile_data = self.step9_test_api_access()
+
+            self.log("=" * 60)
+            self.log("AUTHENTICATION FLOW COMPLETED SUCCESSFULLY!")
+            self.log("=" * 60)
+
+            return {"success": True, "tokens": tokens, "profile_data": profile_data}
+
+        except Exception as e:
+            self.log(f"Authentication flow failed: {str(e)}", "ERROR")
+            # Re-raise with more specific error type if possible
+            if isinstance(e, (AulaAuthenticationError, NetworkError)):
+                raise
+            else:
+                raise AulaAuthenticationError(f"Authentication failed: {str(e)}")
+
+    def get_mitid_client(self):
+        """Get the MitID BrowserClient if available."""
+        return getattr(self, "mitid_client", None)
+
+    def get_qr_codes_svg(self):
+        """Get QR codes as SVG strings for UI display."""
+        if not self.mitid_client:
+            return None
+
+        qr_codes = self.mitid_client.get_current_qr_codes()
+        if not qr_codes:
+            return None
+
+        qr1, qr2 = qr_codes
+        return (self._qr_to_svg(qr1), self._qr_to_svg(qr2))
+
+    def _qr_to_svg(self, qr_code):
+        """Convert QR code object to SVG string."""
+        matrix = qr_code.get_matrix()
+        size = len(matrix)
+        cell_size = 10
+
+        svg_parts = [
+            f'<svg xmlns="http://www.w3.org/2000/svg" '
+            f'width="{size * cell_size}" height="{size * cell_size}" '
+            f'viewBox="0 0 {size} {size}">',
+            '<rect width="100%" height="100%" fill="white"/>',
+        ]
+
+        for y, row in enumerate(matrix):
+            for x, cell in enumerate(row):
+                if cell:
+                    svg_parts.append(
+                        f'<rect x="{x}" y="{y}" width="1" height="1" fill="black"/>'
+                    )
+
+        svg_parts.append("</svg>")
+        return "".join(svg_parts)
+
+    def login_and_save_token(self, token_file_path: str = "tokens.json") -> Dict:
+        """
+        Perform login and save token information to a JSON file.
+
+        Args:
+            token_file_path: Path where to save the token JSON file (default: "tokens.json")
+
+        Returns:
+            Dict containing authentication result and token information
+
+        Raises:
+            AulaAuthenticationError: If login fails
+            IOError: If unable to save token file
+        """
+        self.log(f"Starting login flow with token save to: {token_file_path}")
+
+        try:
+            # Perform authentication
+            auth_result = self.authenticate()
+
+            if not auth_result.get("success"):
+                raise AulaAuthenticationError("Authentication flow did not succeed")
+
+            # Prepare token data with metadata
+            token_data = {
+                "timestamp": time.time(),
+                "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                "username": self.mitid_username,
+                "auth_method": self.auth_method,
+                "tokens": auth_result["tokens"],
+                "client_info": {
+                    "client_id": self.client_id_level_3,
+                    "scope": self.scope,
+                },
+            }
+
+            # Add expiration information if available
+            if "expires_in" in auth_result["tokens"]:
+                expires_at = time.time() + auth_result["tokens"]["expires_in"]
+                token_data["expires_at"] = expires_at
+                token_data["expires_at_readable"] = time.strftime(
+                    "%Y-%m-%d %H:%M:%S", time.localtime(expires_at)
+                )
+
+            # Save to file
+            token_path = Path(token_file_path)
+            token_path.parent.mkdir(parents=True, exist_ok=True)
+
+            with open(token_path, "w") as f:
+                json.dump(token_data, f, indent=2)
+
+            self.log(f" Token data saved successfully to: {token_file_path}")
+
+            return {
+                "success": True,
+                "token_file": str(token_path),
+                "tokens": auth_result["tokens"],
+                "expires_at": token_data.get("expires_at"),
+                "profile_data": auth_result.get("profile_data"),
+            }
+
+        except Exception as e:
+            self.log(f"Login and save failed: {str(e)}", "ERROR")
+            raise
+
+    def get_valid_token(self, token_file_path: str = "tokens.json") -> Optional[Dict]:
+        """
+        Check for existing token, validate it, and return it if valid.
+        If token is expired but refresh token is available, attempt to renew.
+        If renewal fails or no valid token exists, return None.
+
+        Args:
+            token_file_path: Path to the token JSON file (default: "tokens.json")
+
+        Returns:
+            Dict containing valid token information, or None if no valid token available
+        """
+        self.log(f"Checking for valid token in: {token_file_path}")
+
+        token_path = Path(token_file_path)
+
+        # Check if token file exists
+        if not token_path.exists():
+            self.log(f"Token file does not exist: {token_file_path}")
+            return None
+
+        try:
+            # Load token data
+            with open(token_path, "r") as f:
+                token_data = json.load(f)
+
+            # Validate token data structure
+            if not isinstance(token_data, dict) or "tokens" not in token_data:
+                self.log("Invalid token file format", "WARN")
+                return None
+
+            tokens = token_data["tokens"]
+            if not tokens.get("access_token"):
+                self.log("No access token found in file", "WARN")
+                return None
+
+            # Set the tokens in the client
+            self.tokens = tokens
+
+            # Check if token is expired using file metadata
+            if "expires_at" in token_data:
+                current_time = time.time()
+                if current_time >= token_data["expires_at"]:
+                    self.log("Token expired according to file metadata")
+                    return self._attempt_token_renewal(token_data, token_path)
+
+            # Check token validity by examining JWT payload
+            token_check = self.check_token_expiration()
+
+            if token_check.get("valid"):
+                expires_in = token_check.get("expires_in", 0)
+                self.log(f" Token is valid! Expires in {int(expires_in)} seconds")
+
+                # Test actual token validity with API call
+                if self.test_token_validity():
+                    return {
+                        "success": True,
+                        "tokens": tokens,
+                        "source": "cached",
+                        "expires_in": expires_in,
+                        "expires_at": token_check.get("expires_at"),
+                        "cached_data": token_data,
+                    }
+                else:
+                    self.log("Token failed API validation test")
+                    return self._attempt_token_renewal(token_data, token_path)
+            else:
+                self.log(
+                    f"Token not valid: {token_check.get('reason', 'Unknown reason')}"
+                )
+                return self._attempt_token_renewal(token_data, token_path)
+
+        except (json.JSONDecodeError, IOError) as e:
+            self.log(f"Error reading token file: {str(e)}", "ERROR")
+            return None
+        except Exception as e:
+            self.log(f"Unexpected error during token validation: {str(e)}", "ERROR")
+            return None
+
+    def _attempt_token_renewal(
+        self, token_data: Dict, token_path: Path
+    ) -> Optional[Dict]:
+        """
+        Attempt to renew the token using refresh token.
+
+        Args:
+            token_data: Original token data from file
+            token_path: Path to token file
+
+        Returns:
+            Dict with renewed token info, or None if renewal fails
+        """
+        self.log("Attempting token renewal...")
+
+        if not token_data["tokens"].get("refresh_token"):
+            self.log("No refresh token available for renewal")
+            return None
+
+        try:
+            # Attempt renewal
+            if self.renew_access_token():
+                self.log("Token renewed successfully")
+
+                # Update token data with new tokens
+                token_data["tokens"] = self.tokens
+                token_data["renewed_at"] = time.time()
+                token_data["renewed_at_readable"] = time.strftime("%Y-%m-%d %H:%M:%S")
+
+                # Update expiration info
+                if "expires_in" in self.tokens:
+                    expires_at = time.time() + self.tokens["expires_in"]
+                    token_data["expires_at"] = expires_at
+                    token_data["expires_at_readable"] = time.strftime(
+                        "%Y-%m-%d %H:%M:%S", time.localtime(expires_at)
+                    )
+
+                # Save updated tokens
+                with open(token_path, "w") as f:
+                    json.dump(token_data, f, indent=2)
+
+                self.log(f"Updated token file saved: {token_path}")
+
+                return {
+                    "success": True,
+                    "tokens": self.tokens,
+                    "source": "renewed",
+                    "expires_in": self.tokens.get("expires_in"),
+                    "expires_at": token_data.get("expires_at"),
+                    "cached_data": token_data,
+                }
+            else:
+                self.log("Token renewal failed")
+                return None
+
+        except Exception as e:
+            self.log(f"Token renewal failed with exception: {str(e)}", "ERROR")
+            return None
+
+    @property
+    def access_token(self) -> Optional[str]:
+        """Get the current access token"""
+        return self.tokens.get("access_token") if self.tokens else None
+
+    @property
+    def refresh_token(self) -> Optional[str]:
+        """Get the current refresh token"""
+        return self.tokens.get("refresh_token") if self.tokens else None
+
+    def is_authenticated(self) -> bool:
+        """Check if the client has valid tokens"""
+        return bool(self.tokens and self.tokens.get("access_token"))
+
+    def get_current_qr_codes(self):
+        """Get current QR codes from MitID client if available"""
+        if self.mitid_client and hasattr(self.mitid_client, "get_current_qr_codes"):
+            return self.mitid_client.get_current_qr_codes()
+        return None
+
+    def get_valid_access_token(self, token_file_path: str = "tokens.json") -> Dict:
+        """
+        Simple function to get a valid access token.
+
+        This function will:
+        1. Check if the current token is still valid
+        2. If expired, try to refresh it using the token from the JSON file
+        3. Test the token by making an actual API call
+        4. If token test fails, return a "token not valid" error
+
+        Args:
+            token_file_path: Path to the token JSON file (default: "tokens.json")
+
+        Returns:
+            Dict with structure:
+            - success: bool - Whether a valid token was obtained
+            - access_token: str - The valid access token (if success=True)
+            - error: str - Error message (if success=False)
+            - expires_in: int - Seconds until token expires (if success=True)
+        """
+        self.log("Checking for valid access token...")
+
+        try:
+            # First, try to get a valid token from cache/file
+            token_result = self.get_valid_token(token_file_path)
+            if token_result and token_result.get("success"):
+                # Double-check by actually testing the token with an API call
+                self.log("Testing token validity with API call...")
+                if self.test_token_validity():
+                    self.log("Token validation successful")
+                    return {
+                        "success": True,
+                        "access_token": token_result["tokens"]["access_token"],
+                        "expires_in": token_result.get("expires_in", 0),
+                        "source": token_result.get("source", "unknown"),
+                    }
+                else:
+                    self.log("Token failed API validation test")
+                    return {
+                        "success": False,
+                        "error": "Token exists but failed API validation test",
+                        "details": "Token was found and appears valid but failed when tested against the API",
+                    }
+            else:
+                self.log("Unable to obtain valid token")
+                return {
+                    "success": False,
+                    "error": "Token not valid and could not be refreshed",
+                    "details": "Either no token file exists, token is expired and refresh failed, or no refresh token available",
+                }
+
+        except Exception as e:
+            self.log(f"Exception while getting valid token: {str(e)}", "ERROR")
+            return {
+                "success": False,
+                "error": f"Exception occurred: {str(e)}",
+                "details": "An unexpected error occurred while trying to get a valid token",
+            }

--- a/custom_components/aula_easyiq/aula_login_client/exceptions.py
+++ b/custom_components/aula_easyiq/aula_login_client/exceptions.py
@@ -1,0 +1,43 @@
+"""
+Custom exceptions for the Aula Login Client module.
+"""
+
+
+class AulaAuthenticationError(Exception):
+    """Base exception for Aula authentication errors."""
+    pass
+
+
+class MitIDError(AulaAuthenticationError):
+    """Exception raised for MitID authentication failures."""
+    pass
+
+
+class TokenExpiredError(AulaAuthenticationError):
+    """Exception raised when access token has expired."""
+    pass
+
+
+class APIError(AulaAuthenticationError):
+    """Exception raised for API access errors."""
+    pass
+
+
+class ConfigurationError(AulaAuthenticationError):
+    """Exception raised for configuration or setup errors."""
+    pass
+
+
+class NetworkError(AulaAuthenticationError):
+    """Exception raised for network-related errors."""
+    pass
+
+
+class SAMLError(AulaAuthenticationError):
+    """Exception raised for SAML flow errors."""
+    pass
+
+
+class OAuthError(AulaAuthenticationError):
+    """Exception raised for OAuth flow errors."""
+    pass

--- a/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/BrowserClient.py
+++ b/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/BrowserClient.py
@@ -1,0 +1,789 @@
+import requests, time, hashlib, base64, hmac, qrcode, threading, json, logging
+from .CustomSRP import CustomSRP, hex_to_bytes, bytes_to_hex, pad
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BrowserClient:
+    def __init__(
+        self,
+        client_hash: str,
+        authentication_session_id: str,
+        requests_session=requests.Session(),
+    ):
+        self.qr_display_thread_lock = threading.Lock()
+        self.session = requests_session
+
+        self.client_hash = client_hash
+        self.authentication_session_id = authentication_session_id
+
+        r = self.session.get(
+            f"https://www.mitid.dk/mitid-core-client-backend/v1/authentication-sessions/{authentication_session_id}"
+        )
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Failed to get authentication session ({authentication_session_id}), status code {r.status_code}"
+            )
+            raise Exception(r.content)
+
+        r = r.json()
+        # This is all needed for flowValueProofs later on
+        self.broker_security_context = r["brokerSecurityContext"]
+        self.service_provider_name = r["serviceProviderName"]
+        self.reference_text_header = r["referenceTextHeader"]
+        self.reference_text_body = r["referenceTextBody"]
+        self.status_message = (
+            f"Beginning login session for {self.service_provider_name}"
+        )
+        _LOGGER.info(f"Beginning login session for {self.service_provider_name}")
+        _LOGGER.debug(f"{self.reference_text_header}")
+        _LOGGER.debug(f"{self.reference_text_body}")
+
+    def __display_qr_ascii(self, stop_event):
+
+        frame = True
+        while not stop_event.is_set():
+            # os.system("cls" if os.name == "nt" else "clear")
+            # print("Scan this QR Code in the app:")
+            qr1, qr2 = self.__get_qr_codes()
+            # print(render_qr(qr1) if frame else render_qr(qr2))
+            frame = not frame
+            stop_event.wait(1)
+
+    def __set_qr_codes(self, qr1, qr2):
+        with self.qr_display_thread_lock:
+            self.qr1 = qr1
+            self.qr2 = qr2
+
+    def __get_qr_codes(self):
+        with self.qr_display_thread_lock:
+            return self.qr1, self.qr2
+
+    def get_current_qr_codes(self):
+        """Get current QR codes for external display (e.g., Home Assistant GUI)."""
+        try:
+            return self.__get_qr_codes()
+        except AttributeError:
+            return None
+
+    def start_app_authentication(self):
+        """Start APP authentication and return poll information."""
+        self.__select_authenticator("APP")
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/init-auth",
+            json={},
+        )
+        if r.status_code != 200:
+            raise Exception(f"Failed to request app login, status code {r.status_code}")
+
+        r = r.json()
+        if (
+            "errorCode" in r
+            and r["errorCode"]
+            == "auth.codeapp.authentication.parallel_sessions_detected"
+        ):
+            raise Exception("Parallel app sessions detected")
+
+        self.poll_url = r["pollUrl"]
+        self.ticket = r["ticket"]
+        self.auth_status = "waiting"
+        self.status_message = "Waiting for MitID app"
+        self.otp_code = None
+        return {"poll_url": self.poll_url, "ticket": self.ticket}
+
+    def poll_app_authentication_status(self):
+        """Poll once for APP authentication status. Returns status dict."""
+        if not hasattr(self, "poll_url"):
+            raise Exception(
+                "Authentication not started - call start_app_authentication() first"
+            )
+
+        r = self.session.post(self.poll_url, json={"ticket": self.ticket})
+
+        if r.status_code != 200:
+            return {"status": "error", "message": "Poll request failed"}
+
+        data = r.json()
+        status = data.get("status")
+
+        if status == "timeout":
+            return {"status": "waiting", "message": "Waiting for response..."}
+
+        elif status == "channel_validation_otp":
+            self.otp_code = data["channelBindingValue"]
+            self.status_message = f"Use OTP code: {self.otp_code}"
+            return {
+                "status": "otp_ready",
+                "message": self.status_message,
+                "otp_code": self.otp_code,
+            }
+
+        elif status == "channel_validation_tqr":
+            # Generate QR codes
+            channel_binding = data["channelBindingValue"]
+            half = int(len(channel_binding) / 2)
+
+            qr_data_1 = {
+                "v": 1,
+                "p": 1,
+                "t": 2,
+                "h": channel_binding[:half],
+                "uc": data["updateCount"],
+            }
+            qr1 = qrcode.QRCode(border=1)
+            qr1.add_data(json.dumps(qr_data_1, separators=(",", ":")))
+            qr1.make()
+
+            qr_data_2 = {
+                "v": 1,
+                "p": 2,
+                "t": 2,
+                "h": channel_binding[half:],
+                "uc": data["updateCount"],
+            }
+            qr2 = qrcode.QRCode(border=1)
+            qr2.add_data(json.dumps(qr_data_2, separators=(",", ":")))
+            qr2.make()
+
+            self.__set_qr_codes(qr1, qr2)
+            self.status_message = "Scan QR code with MitID app"
+            return {"status": "qr_ready", "message": self.status_message}
+
+        elif status == "channel_verified":
+            self.status_message = "QR verified, waiting for approval"
+            return {"status": "verified", "message": self.status_message}
+
+        elif status == "OK" and data.get("confirmation") == True:
+            # Authentication completed
+            self.auth_response = data["payload"]["response"]
+            self.auth_response_signature = data["payload"]["responseSignature"]
+            return {"status": "completed", "message": "Authentication successful"}
+
+        else:
+            return {"status": "error", "message": "Authentication was not accepted"}
+
+    def complete_app_authentication(self):
+        """Complete APP authentication after polling succeeds. Returns finalization session ID."""
+        if not hasattr(self, "auth_response"):
+            raise Exception(
+                "Authentication not completed - poll until status is 'completed'"
+            )
+
+        # SRP protocol stages
+        timer_1 = time.time()
+        SRP = CustomSRP()
+        A = SRP.SRPStage1()
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/init",
+            json={"randomA": {"value": A}},
+        )
+        if r.status_code != 200:
+            raise Exception(f"Failed to init app protocol, status code {r.status_code}")
+
+        srpSalt = r.json()["srpSalt"]["value"]
+        randomB = r.json()["randomB"]["value"]
+
+        m = hashlib.sha256()
+        m.update(
+            base64.b64decode(self.auth_response)
+            + self.current_authenticator_session_flow_key.encode("utf8")
+        )
+        password = m.hexdigest()
+
+        m1 = SRP.SRPStage3(
+            srpSalt, randomB, password, self.current_authenticator_session_id
+        )
+
+        unhashed_flow_value_proof = self.__create_flow_value_proof()
+        m = hashlib.sha256()
+        unhashed_flow_value_proof_key = "flowValues" + bytes_to_hex(SRP.K_bits)
+        m.update(unhashed_flow_value_proof_key.encode("utf8"))
+        hashed_flow_value_proof_key = m.hexdigest()
+        hmac_flow_value_proof = hmac.new(
+            hex_to_bytes(hashed_flow_value_proof_key),
+            unhashed_flow_value_proof,
+            hashlib.sha256,
+        ).digest()
+        flow_value_proof = base64.b64encode(hmac_flow_value_proof).decode("ascii")
+
+        # Complete authentication
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/complete",
+            json={"M1": {"value": m1}, "flowValueProof": {"value": flow_value_proof}},
+        )
+        if r.status_code != 200:
+            raise Exception(
+                f"Failed to complete app authentication, status code {r.status_code}"
+            )
+
+        self.status_message = "App login was accepted, finalizing authentication"
+        _LOGGER.info(
+            "App login was accepted, you can now finalize authentication and receive your authorization code"
+        )
+        self.finalization_authentication_session_id = r.json()[
+            "authenticationSessionId"
+        ]
+        return self.finalization_authentication_session_id
+
+    def __convert_human_authenticator_name_to_combination_id(self, authenticator_name):
+        match authenticator_name:
+            case "APP":
+                return "S3"
+            case "TOKEN":
+                return "S1"
+            case _:
+                raise Exception(f"No such authenticator name ({authenticator_name})")
+
+    def __convert_combination_id_to_human_authenticator_name(self, combination_id):
+        match combination_id:
+            case "S4":  # App + MitID chip
+                return "APP"
+            case "S3":
+                return "APP"
+            case "L2":
+                return "APP"
+            case "S1":
+                return "TOKEN"
+            case _:
+                raise Exception(f"No such combination ID ({combination_id})")
+
+    def identify_as_user_and_get_available_authenticators(self, user_id):
+        self.user_id = user_id
+        r = self.session.put(
+            f"https://www.mitid.dk/mitid-core-client-backend/v1/authentication-sessions/{self.authentication_session_id}",
+            json={"identityClaim": user_id},
+        )
+
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Received status code ({r.status_code}) while attempting to identify as user ({user_id})"
+            )
+            if (
+                r.status_code == 400
+                and r.json()["errorCode"] == "control.identity_not_found"
+            ):
+                _LOGGER.error(f"User '{user_id}' does not exist.")
+                raise Exception(r.content)
+
+            if (
+                r.status_code == 400
+                and r.json()["errorCode"] == "control.authentication_session_not_found"
+            ):
+                _LOGGER.error("Authentication session not found")
+                raise Exception(r.content)
+
+            raise Exception(r.content)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-core-client-backend/v2/authentication-sessions/{self.authentication_session_id}/next",
+            json={"combinationId": ""},
+        )
+
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Received status code ({r.status_code}) while attempting to get authenticators for user ({user_id})"
+            )
+            raise Exception(r.content)
+
+        r = r.json()
+        if (
+            r["errors"]
+            and len(r["errors"]) > 0
+            and r["errors"][0]["errorCode"] == "control.authenticator_cannot_be_started"
+        ):
+            error_text = r["errors"][0]["userMessage"]["text"]["text"]
+            _LOGGER.error(
+                f"Could not get authenticators, got the following error text: {error_text}"
+            )
+            raise Exception(error_text)
+
+        self.current_authenticator_type = r["nextAuthenticator"]["authenticatorType"]
+        self.current_authenticator_session_flow_key = r["nextAuthenticator"][
+            "authenticatorSessionFlowKey"
+        ]
+        self.current_authenticator_eafe_hash = r["nextAuthenticator"]["eafeHash"]
+        self.current_authenticator_session_id = r["nextAuthenticator"][
+            "authenticatorSessionId"
+        ]
+
+        available_combinations = r["combinations"]
+        available_authenticators = {}
+        for available_combination in available_combinations:
+            available_authenticators[
+                self.__convert_combination_id_to_human_authenticator_name(
+                    available_combination["id"]
+                )
+            ] = available_combination["combinationItems"][0]["name"]
+
+        return available_authenticators
+
+    def __create_flow_value_proof(self):
+        hashed_broker_security_context = hashlib.sha256(
+            self.broker_security_context.encode("utf8")
+        ).hexdigest()
+        base64_reference_text_header = base64.b64encode(
+            (self.reference_text_header.encode("utf8"))
+        ).decode("ascii")
+        base64_reference_text_body = base64.b64encode(
+            (self.reference_text_body.encode("utf8"))
+        ).decode("ascii")
+        base64_service_provider_name = base64.b64encode(
+            (self.service_provider_name.encode("utf8"))
+        ).decode("ascii")
+        return f"{self.current_authenticator_session_id},{self.current_authenticator_session_flow_key},{self.client_hash},{self.current_authenticator_eafe_hash},{hashed_broker_security_context},{base64_reference_text_header},{base64_reference_text_body},{base64_service_provider_name}".encode(
+            "utf-8"
+        )
+
+    def __select_authenticator(self, authenticator_type: str):
+        if authenticator_type == self.current_authenticator_type:
+            return
+
+        combination_id = self.__convert_human_authenticator_name_to_combination_id(
+            authenticator_type
+        )
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-core-client-backend/v2/authentication-sessions/{self.authentication_session_id}/next",
+            json={"combinationId": combination_id},
+        )
+
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Received status code ({r.status_code}) while attempting to get authenticators for user ({self.user_id})"
+            )
+            raise Exception(r.content)
+
+        r = r.json()
+        if (
+            r["errors"]
+            and len(r["errors"]) > 0
+            and r["errors"][0]["errorCode"] == "control.authenticator_cannot_be_started"
+        ):
+            error_text = r["errors"][0]["userMessage"]["text"]["text"]
+            _LOGGER.error(
+                f"Could not get authenticators, got the following error text: {error_text}"
+            )
+            raise Exception(error_text)
+
+        self.current_authenticator_type = r["nextAuthenticator"]["authenticatorType"]
+        self.current_authenticator_session_flow_key = r["nextAuthenticator"][
+            "authenticatorSessionFlowKey"
+        ]
+        self.current_authenticator_eafe_hash = r["nextAuthenticator"]["eafeHash"]
+        self.current_authenticator_session_id = r["nextAuthenticator"][
+            "authenticatorSessionId"
+        ]
+
+        if self.current_authenticator_type != authenticator_type:
+            raise Exception(
+                f"Was not able to choose the desired authenticator ({authenticator_type}), instead we received ({self.current_authenticator_type})"
+            )
+
+    def authenticate_with_token(self, token_digits: str):
+        self.__select_authenticator("TOKEN")
+
+        timer_1 = time.time()
+        SRP = CustomSRP()
+        A = SRP.SRPStage1()
+        timer_1 = time.time() - timer_1
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-token-auth/v1/authenticator-sessions/{self.current_authenticator_session_id}/codetoken-init",
+            json={"randomA": {"value": A}},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Failed to init TOTP code protocol, status code {r.status_code}"
+            )
+            raise Exception(r.content)
+
+        timer_2 = time.time()
+        r = r.json()
+        # pbkdfSalt is not actually used even though we receive it, what the hell are they doing here?
+        # This seems like schlock
+        # pbkdfSalt = r["pbkdf2Salt"]["value"]
+        srpSalt = r["srpSalt"]["value"]
+        randomB = r["randomB"]["value"]
+
+        m1 = SRP.SRPStage3(
+            srpSalt,
+            randomB,
+            bytes_to_hex(self.current_authenticator_session_flow_key.encode("utf-8")),
+            self.current_authenticator_session_id,
+        )
+
+        unhashed_flow_value_proof = self.__create_flow_value_proof()
+        m = hashlib.sha256()
+        unhashed_flow_value_proof_key = "OTP" + token_digits + bytes_to_hex(SRP.K_bits)
+        m.update(unhashed_flow_value_proof_key.encode("utf8"))
+        flow_value_proof_key = m.digest()
+
+        flow_value_proof = hmac.new(
+            flow_value_proof_key, unhashed_flow_value_proof, hashlib.sha256
+        ).hexdigest()
+
+        timer_2 = time.time() - timer_2
+        front_end_processing_time = int((timer_1 + timer_2) * 1000)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-token-auth/v1/authenticator-sessions/{self.current_authenticator_session_id}/codetoken-prove",
+            json={
+                "m1": {"value": m1},
+                "flowValueProof": {"value": flow_value_proof},
+                "frontEndProcessingTime": front_end_processing_time,
+            },
+        )
+        if r.status_code != 204:
+            _LOGGER.error(f"Failed to submit TOTP code, status code {r.status_code}")
+            raise Exception(r.content)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-core-client-backend/v2/authentication-sessions/{self.authentication_session_id}/next",
+            json={"combinationId": ""},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(f"Failed to prove TOTP code, status code {r.status_code}")
+            raise Exception(r.content)
+
+        if (
+            r.json()["errors"]
+            and len(r.json()["errors"]) > 0
+            and r.json()["errors"][0]["errorCode"] == "TOTP_INVALID"
+        ):
+            error_text = r.json()["errors"][0]["message"]
+            _LOGGER.error(
+                f"Could not log in with the provided TOTP code, got the following message: {error_text}"
+            )
+            raise Exception(r.content)
+
+        r = r.json()
+        if (
+            "nextAuthenticator" not in r
+            or "authenticatorType" not in r["nextAuthenticator"]
+            or r["nextAuthenticator"]["authenticatorType"] != "PASSWORD"
+        ):
+            _LOGGER.error(
+                f"Ran into an unexpected situation, was expecting to be asked for password after TOTP but got the following response"
+            )
+            raise Exception(r.content)
+
+        self.current_authenticator_type = r["nextAuthenticator"]["authenticatorType"]
+        self.current_authenticator_session_flow_key = r["nextAuthenticator"][
+            "authenticatorSessionFlowKey"
+        ]
+        self.current_authenticator_eafe_hash = r["nextAuthenticator"]["eafeHash"]
+        self.current_authenticator_session_id = r["nextAuthenticator"][
+            "authenticatorSessionId"
+        ]
+        _LOGGER.info("Token code accepted, you now need to validate your password")
+
+    def authenticate_with_password(self, password: str):
+        if self.current_authenticator_type != "PASSWORD":
+            raise Exception(
+                f"You cannot authenticate with password before completing authentication with token code, the current authenticator type was ({self.current_authenticator_type})"
+            )
+
+        timer_1 = time.time()
+        SRP = CustomSRP()
+        A = SRP.SRPStage1()
+        timer_1 = time.time() - timer_1
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-password-auth/v1/authenticator-sessions/{self.current_authenticator_session_id}/init",
+            json={"randomA": {"value": A}},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Failed to init password protocol, status code {r.status_code}"
+            )
+            raise Exception(r.content)
+
+        timer_2 = time.time()
+        r = r.json()
+        pbkdfSalt = r["pbkdf2Salt"]["value"]
+        srpSalt = r["srpSalt"]["value"]
+        randomB = r["randomB"]["value"]
+
+        password = hashlib.pbkdf2_hmac(
+            "sha256", password.encode("utf-8"), hex_to_bytes(pbkdfSalt), 20000, 32
+        ).hex()
+
+        m1 = SRP.SRPStage3(
+            srpSalt, randomB, password, self.current_authenticator_session_id
+        )
+
+        unhashed_flow_value_proof = self.__create_flow_value_proof()
+        m = hashlib.sha256()
+        unhashed_flow_value_proof_key = "flowValues" + bytes_to_hex(SRP.K_bits)
+        m.update(unhashed_flow_value_proof_key.encode("utf8"))
+        flow_value_proof_key = m.digest()
+
+        flow_value_proof = hmac.new(
+            flow_value_proof_key, unhashed_flow_value_proof, hashlib.sha256
+        ).hexdigest()
+
+        timer_2 = time.time() - timer_2
+        front_end_processing_time = int((timer_1 + timer_2) * 1000)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-password-auth/v1/authenticator-sessions/{self.current_authenticator_session_id}/password-prove",
+            json={
+                "m1": {"value": m1},
+                "flowValueProof": {"value": flow_value_proof},
+                "frontEndProcessingTime": front_end_processing_time,
+            },
+        )
+        if r.status_code != 204:
+            _LOGGER.error(f"Failed to submit password, status code {r.status_code}")
+            raise Exception(r.content)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-core-client-backend/v2/authentication-sessions/{self.authentication_session_id}/next",
+            json={"combinationId": ""},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(f"Failed to prove password, status code {r.status_code}")
+            raise Exception(r.content)
+
+        r = r.json()
+        if r["errors"] and len(r["errors"]) > 0:
+            if r["errors"][0]["errorCode"] == "PASSWORD_INVALID":
+                error_text = r["errors"][0]["message"]
+                _LOGGER.error(
+                    f"Could not log in with the provided password, got the following message: {error_text}"
+                )
+                raise Exception(error_text)
+            elif r["errors"][0]["errorCode"] == "core.psd2.error":
+                error_text = r["errors"][0]["message"]
+                _LOGGER.error(
+                    f"Could not log in due to an error, probably due to a wrong password provided. Got the following message: {error_text}"
+                )
+                raise Exception(error_text)
+            else:
+                error_text = r["errors"][0]["message"]
+                _LOGGER.error(
+                    f"Could not log in due to an unknown error, got the following message: {error_text}"
+                )
+                raise Exception(error_text)
+
+        self.finalization_authentication_session_id = r["nextSessionId"]
+        self.status_message = "Password accepted, finalizing authentication"
+        _LOGGER.info(
+            "Password was accepted, you can now finalize authentication and receive your authorization code"
+        )
+
+    def authenticate_with_app(self):
+        self.__select_authenticator("APP")
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/init-auth",
+            json={},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(f"Failed to request app login, status code {r.status_code}")
+            raise Exception(r.content)
+
+        r = r.json()
+        if (
+            "errorCode" in r
+            and r["errorCode"]
+            == "auth.codeapp.authentication.parallel_sessions_detected"
+        ):
+            _LOGGER.error(
+                "Parallel app sessions detected, only a single app login session can be happening at any one time"
+            )
+            raise Exception(
+                "Parallel app sessions detected. Please wait a few minutes before trying again."
+            )
+
+        poll_url = r["pollUrl"]
+        ticket = r["ticket"]
+        self.status_message = "Login request has been made, open your MitID app now"
+        _LOGGER.info("Login request has been made, open your MitID app now")
+        qr_stop_event = None
+        qr_display_thread = None
+        while True:
+            r = self.session.post(poll_url, json={"ticket": ticket})
+
+            if r.status_code == 200 and r.json()["status"] == "timeout":
+                continue
+
+            if r.status_code == 200 and r.json()["status"] == "channel_validation_otp":
+                self.status_message = f"Please use the following OTP code in the app: {r.json()['channelBindingValue']}"
+                _LOGGER.info(
+                    f"Please use the following OTP code in the app: {r.json()['channelBindingValue']}"
+                )
+                continue
+
+            if r.status_code == 200 and r.json()["status"] == "channel_validation_tqr":
+                qr_data = {
+                    "v": 1,
+                    "p": 1,
+                    "t": 2,
+                    "h": r.json()["channelBindingValue"][
+                        : int(len(r.json()["channelBindingValue"]) / 2)
+                    ],
+                    "uc": r.json()["updateCount"],
+                }
+                qr1 = qrcode.QRCode(border=1)
+                qr1.add_data(json.dumps(qr_data, separators=(",", ":")))
+                qr1.make()
+
+                qr_data["p"] = 2
+                qr_data["h"] = r.json()["channelBindingValue"][
+                    int(len(r.json()["channelBindingValue"]) / 2) :
+                ]
+
+                qr2 = qrcode.QRCode(border=1)
+                qr2.add_data(json.dumps(qr_data, separators=(",", ":")))
+                qr2.make()
+
+                self.__set_qr_codes(qr1, qr2)
+
+                if qr_stop_event is None:
+                    qr_stop_event = threading.Event()
+                    qr_display_thread = threading.Thread(
+                        target=self.__display_qr_ascii, args=[qr_stop_event]
+                    )
+                    qr_display_thread.start()
+
+                continue
+
+            if r.status_code == 200 and r.json()["status"] == "channel_verified":
+                if qr_display_thread and qr_display_thread.is_alive():
+                    qr_stop_event.set()
+                    qr_display_thread.join()
+                self.status_message = "The OTP/QR code has been verified, now waiting user to approve login"
+                _LOGGER.info(
+                    "The OTP/QR code has been verified, now waiting user to approve login"
+                )
+                continue
+
+            if not (
+                r.status_code == 200
+                and r.json()["status"] == "OK"
+                and r.json()["confirmation"] == True
+            ):
+                if qr_display_thread and qr_display_thread.is_alive():
+                    qr_stop_event.set()
+                    qr_display_thread.join()
+                _LOGGER.error("Login request was not accepted")
+                raise Exception(r.content)
+
+            break
+
+        r = r.json()
+        response = r["payload"]["response"]
+        response_signature = r["payload"]["responseSignature"]
+
+        timer_1 = time.time()
+        SRP = CustomSRP()
+        A = SRP.SRPStage1()
+        timer_1 = time.time() - timer_1
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/init",
+            json={"randomA": {"value": A}},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(f"Failed to init app protocol, status code {r.status_code}")
+            raise Exception(r.content)
+
+        timer_2 = time.time()
+        srpSalt = r.json()["srpSalt"]["value"]
+        randomB = r.json()["randomB"]["value"]
+
+        m = hashlib.sha256()
+        m.update(
+            base64.b64decode(response)
+            + self.current_authenticator_session_flow_key.encode("utf8")
+        )
+        password = m.hexdigest()
+
+        m1 = SRP.SRPStage3(
+            srpSalt, randomB, password, self.current_authenticator_session_id
+        )
+
+        unhashed_flow_value_proof = self.__create_flow_value_proof()
+        m = hashlib.sha256()
+        unhashed_flow_value_proof_key = "flowValues" + bytes_to_hex(SRP.K_bits)
+        m.update(unhashed_flow_value_proof_key.encode("utf8"))
+        flow_value_proof_key = m.digest()
+
+        flow_value_proof = hmac.new(
+            flow_value_proof_key, unhashed_flow_value_proof, hashlib.sha256
+        ).hexdigest()
+
+        timer_2 = time.time() - timer_2
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/prove",
+            json={"m1": {"value": m1}, "flowValueProof": {"value": flow_value_proof}},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Failed to submit app response proof, status code {r.status_code}"
+            )
+            raise Exception(r.content)
+
+        timer_3 = time.time()
+        m2 = r.json()["m2"]["value"]
+        if not SRP.SRPStage5(m2):
+            raise Exception("m2 could not be validated during proving of app response")
+        auth_enc = base64.b64encode(
+            SRP.AuthEnc(base64.b64decode(pad(response_signature)))
+        ).decode("ascii")
+        timer_3 = time.time() - timer_3
+
+        front_end_processing_time = int((timer_1 + timer_2 + timer_3) * 1000)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-code-app-auth/v1/authenticator-sessions/web/{self.current_authenticator_session_id}/verify",
+            json={
+                "encAuth": auth_enc,
+                "frontEndProcessingTime": front_end_processing_time,
+            },
+        )
+        if r.status_code != 204:
+            _LOGGER.error(
+                f"Failed to verify app response signature, status code {r.status_code}"
+            )
+            raise Exception(r.content)
+
+        r = self.session.post(
+            f"https://www.mitid.dk/mitid-core-client-backend/v2/authentication-sessions/{self.authentication_session_id}/next",
+            json={"combinationId": ""},
+        )
+        if r.status_code != 200:
+            _LOGGER.error(f"Failed to prove app login, status code {r.status_code}")
+            raise Exception(r.content)
+
+        r = r.json()
+        if r["errors"] and len(r["errors"]) > 0:
+            _LOGGER.error(f"Could not prove the app login")
+            raise Exception("Could not prove the app login. Please try again.")
+
+        self.finalization_authentication_session_id = r["nextSessionId"]
+        self.status_message = "App login was accepted, finalizing authentication"
+        _LOGGER.info(
+            "App login was accepted, you can now finalize authentication and receive your authorization code"
+        )
+
+    def finalize_authentication_and_get_authorization_code(self):
+        if not self.finalization_authentication_session_id:
+            raise Exception(
+                "No finalization session ID set, make sure you have completed an authentication flow."
+            )
+
+        r = self.session.put(
+            f"https://www.mitid.dk/mitid-core-client-backend/v1/authentication-sessions/{self.finalization_authentication_session_id}/finalization"
+        )
+        if r.status_code != 200:
+            _LOGGER.error(
+                f"Failed to retrieve authorization code, status code {r.status_code}"
+            )
+            raise Exception(r.content)
+
+        return r.json()["authorizationCode"]

--- a/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/CustomSRP.py
+++ b/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/CustomSRP.py
@@ -1,0 +1,158 @@
+import base64
+import random
+import binascii
+import hashlib
+from Crypto.Cipher import AES
+from Crypto import Random
+
+BLOCK_SIZE = 16
+pad = lambda s: s + (BLOCK_SIZE - len(s) % BLOCK_SIZE) * chr(BLOCK_SIZE - len(s) % BLOCK_SIZE)
+unpad = lambda s: s[:-ord(s[len(s) - 1:])]
+
+def int_to_hex(x):
+    return format(x, 'x')
+
+def int_to_bytes(x):
+    return x.to_bytes((x.bit_length() + 7) // 8, 'big')
+
+def bytes_to_int(x):
+    return int.from_bytes(x, 'big')
+
+def bytes_to_hex(x):
+    return binascii.hexlify(x).decode('utf-8')
+
+def hex_to_bytes(x):
+    return binascii.unhexlify(x)
+
+def hex_to_int(x):
+    return int(x, 16)
+
+def AesDecryptWithKey(encMessage, key):
+    encMessage = base64.b64decode(encMessage)
+
+    iv = encMessage[:BLOCK_SIZE]
+    cipherText = encMessage[BLOCK_SIZE:len(encMessage)-BLOCK_SIZE]
+    macTag = encMessage[len(encMessage)-BLOCK_SIZE:]
+
+    cipher = AES.new(key, AES.MODE_GCM, iv)
+    decrypted = cipher.decrypt_and_verify(cipherText, macTag)
+    return decrypted
+
+class CustomSRP():
+    def SRPStage1(self):
+        self.N = 4983313092069490398852700692508795473567251422586244806694940877242664573189903192937797446992068818099986958054998012331720869136296780936009508700487789962429161515853541556719593346959929531150706457338429058926505817847524855862259333438239756474464759974189984231409170758360686392625635632084395639143229889862041528635906990913087245817959460948345336333086784608823084788906689865566621015175424691535711520273786261989851360868669067101108956159530739641990220546209432953829448997561743719584980402874346226230488627145977608389858706391858138200618631385210304429902847702141587470513336905449351327122086464725143970313054358650488241167131544692349123381333204515637608656643608393788598011108539679620836313915590459891513992208387515629240292926570894321165482608544030173975452781623791805196546326996790536207359143527182077625412731080411108775183565594553871817639221414953634530830290393130518228654795859
+        self.g = 2
+        a = random.getrandbits(256)
+        if a < 0:
+            a += self.N
+        self.a = a
+
+        self.A = pow(self.g, self.a, self.N)
+        return int_to_hex(self.A)
+    
+    def computeLittleS(self):
+        N_bytes = int_to_bytes(self.N)
+        g_bytes = int_to_bytes(self.g)
+        
+        # Prepend g_bytes with |N_bytes|-|g_bytes| of 0
+        g_bytes = (b"\0" * (len(N_bytes) - len(g_bytes))) + g_bytes
+
+        m = hashlib.sha256()
+        m.update(str(self.N).encode('utf-8') + g_bytes)
+        digest = m.hexdigest()
+
+        return hex_to_int(digest)
+
+    def computeU(self):
+        N_length = len(int_to_bytes(self.N))
+        A_bytes = int_to_bytes(self.A)
+        B_bytes = int_to_bytes(self.B)
+
+        # Prepend A_bytes with |N_bytes|-|A_bytes| of 0
+        A_bytes = (b"\0"*(N_length-len(A_bytes)))+A_bytes
+
+        # Prepend r_bytes with |N_bytes|-|r_bytes| of 0
+        B_bytes = (b"\0"*(N_length-len(B_bytes)))+B_bytes
+        
+        m = hashlib.sha256()
+        m.update(A_bytes + B_bytes)
+        hashed = m.hexdigest()
+        u = hex_to_int(hashed) % self.N
+        return u
+
+    def computeSessionKey(self):
+        u = self.computeU()
+        # The MitID app does not seem to perform this safety check
+        # but at least some other implementations do 
+        #if u == 0:
+        #    return None
+
+        s = self.computeLittleS()
+        
+        a = u * self.hashed_password + self.a
+        c = pow((self.B - (pow(self.g, self.hashed_password, self.N) * s)), a, self.N)
+        if a < 0:
+            a += self.N
+
+        return c
+
+    def computeM1(self, r, srpSalt):
+        m = hashlib.sha256()
+        m.update(str(self.N).encode("utf-8"))
+        N = hex_to_int(m.hexdigest())
+
+        m = hashlib.sha256()
+        m.update(str(self.g).encode("utf-8"))
+        g = hex_to_int(m.hexdigest())
+        a = N ^ g
+
+        m = hashlib.sha256()
+        m.update((str(a) + r + srpSalt + str(self.A) + str(self.B) + bytes_to_hex(self.K_bits)).encode("ascii"))
+        return m.hexdigest()
+
+    def SRPStage3(self, srpSalt, randomB, password, auth_session_id):
+        self.B = hex_to_int(randomB)
+
+        if(self.B == 0 or self.B % self.N == 0):
+            raise Exception("randomB did not pass safety check")
+
+        m = hashlib.sha256()
+        m.update((srpSalt + password).encode("ascii"))
+        self.hashed_password = hex_to_int(m.hexdigest())
+
+        a = self.computeSessionKey()
+
+        m = hashlib.sha256()
+        m.update(str(a).encode("utf-8"))
+        self.K_bits = m.digest()
+
+        m = hashlib.sha256()
+        m.update(auth_session_id.encode("utf-8"))
+        I_hex = m.hexdigest()
+
+        self.M1_hex = self.computeM1(I_hex, srpSalt)
+
+        return self.M1_hex
+    
+    # Should satisfy if the server is correct
+    # Interestingly enough, this cannot be checked for the pin-binding proof
+    def SRPStage5(self, M2_hex):
+        M1_bigInt = int(self.M1_hex, 16)
+
+        m = hashlib.sha256()
+        m.update((str(self.A) + str(M1_bigInt) + bytes_to_hex(self.K_bits)).encode('utf-8'))
+        M2_hex_verify = m.hexdigest()
+        return M2_hex_verify == M2_hex
+
+    def AuthEnc(self, plainText):
+        iv = Random.new().read(BLOCK_SIZE)
+        cipher = AES.new(self.K_bits, AES.MODE_GCM, iv)
+        ciphertext, tag = cipher.encrypt_and_digest(plainText)
+        return (iv + ciphertext + tag)
+
+    def AuthDec(self, encMessage):
+        return AesDecryptWithKey(encMessage, self.K_bits)
+    
+    def AuthDecPin(self, encMessage):
+        pin_key = hashlib.sha256(binascii.hexlify(self.K_bits) + b"PIN").digest()
+        return AesDecryptWithKey(encMessage, pin_key)

--- a/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/Helpers.py
+++ b/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/Helpers.py
@@ -1,0 +1,95 @@
+import binascii, base64, hashlib, argparse, logging
+from Crypto import Random
+from .BrowserClient import BrowserClient
+from bs4 import BeautifulSoup
+
+_LOGGER = logging.getLogger(__name__)
+
+# Use this function to add the minimum required args to your login flow
+def get_default_args() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="argparser")
+    parser.add_argument('--user', help='Your MitID username. For example: "GenericDanishCitizen"', required=True)
+    parser.add_argument('--password', help='Your MitID password for use with the "TOKEN" login method. For example: "CorrectHorseBatteryStaple"', required=False)
+    parser.add_argument('--method', choices=['APP', 'TOKEN'], help='Which method to use when logging in to MitID, default APP', default='APP', required=False)
+    parser.add_argument('--proxy', help='An optional socks5 proxy to use for all communication with MitID', required=False)
+    return parser
+
+# Use this function to process the minimum required args for your login flow
+def process_args(args):
+    method = args.method
+    user_id = args.user
+    if args.password and args.method == 'TOKEN':
+        password = args.password
+    elif args.method == 'TOKEN':
+        password = input("Please input your password\n")
+    else:
+        password = None
+    return method, user_id, password, args.proxy
+
+# get_authentication_code is generally generic enough that you do not need to create your own
+# calls to BrowserClient
+def get_authentication_code(session, aux, method, user_id, password):
+    client_hash = binascii.hexlify(base64.b64decode(aux["coreClient"]["checksum"])).decode('ascii')
+    authentication_session_id = aux["parameters"]["authenticationSessionId"]
+
+    MitIDClient = BrowserClient(client_hash, authentication_session_id, session)
+    available_authenticators = MitIDClient.identify_as_user_and_get_available_authenticators(user_id)
+
+    _LOGGER.debug(f"Available authenticator: {available_authenticators}")
+
+    if method == "TOKEN" and "TOKEN" in available_authenticators:
+        token_digits = input("Please input the 6 digits from your code token\n").strip()
+        MitIDClient.authenticate_with_token(token_digits)
+        MitIDClient.authenticate_with_password(password)
+    elif method == "APP" and "APP" in available_authenticators:
+        MitIDClient.authenticate_with_app()
+    elif method == "TOKEN" and "TOKEN" not in available_authenticators:
+        raise Exception(f"Token authentication method chosen but not available for MitID user")
+    elif method == "APP" and "APP" not in available_authenticators:    
+        raise Exception(f"App authentication method chosen but not available for MitID user")
+    else:
+        raise Exception(f"Unknown authenticator method: {method}")
+
+    authorization_code = MitIDClient.finalize_authentication_and_get_authorization_code()
+    return authorization_code
+
+def choose_between_multiple_identitites(session, request, soup):
+    data = {}
+    for soup_input in soup.form.select("input"):
+        try:
+            data[soup_input["name"]] = soup_input["value"]
+        except:    
+            data[soup_input["name"]] = ""
+    login_options = soup.select("div.list-link-box")
+    _LOGGER.info('You can choose between different identities:')
+    identities = []
+    for i, login_option in enumerate(login_options):
+        _LOGGER.info(f'{i+1}: {login_option.select_one("div.list-link-text").string}')
+        identities.append(i+1)
+    identity = input("Enter the identity you want to use:\n").strip()
+    try:
+        if int(identity) in identities:
+            selected_option = login_options[int(identity)-1].a["data-loginoptions"]
+            data["ChosenOptionJson"] = selected_option
+        else: 
+            raise Exception(f"Identity not in list of identities")
+    except:
+        raise Exception(f"Wrongly entered identity")
+    request = session.post(request.url, data=data)
+    soup = BeautifulSoup(request.text, "xml")
+    return request, soup
+
+def __generate_random_string():
+    return binascii.hexlify(Random.new().read(28)).decode("utf-8")
+
+def __generate_challenge(verifier):
+    return base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("utf-8")).digest()).decode("utf-8").rstrip("=")
+
+# Use this function to generate the default parameters for nem_login flows
+def generate_nem_login_parameters():
+    nem_login_state = __generate_random_string()
+    nem_login_nonce = __generate_random_string()
+    nem_login_code_verifier = __generate_random_string()
+    nem_login_code_challenge = __generate_challenge(nem_login_code_verifier)
+
+    return nem_login_state, nem_login_nonce, nem_login_code_verifier, nem_login_code_challenge

--- a/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/__init__.py
+++ b/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/__init__.py
@@ -1,0 +1,30 @@
+"""
+MitID BrowserClient - Unofficial Python implementation of the MitID JavaScript browser client.
+
+This package provides functionality to authenticate with MitID using various methods
+including the MitID app (OTP and QR Code) and code token reader devices.
+"""
+
+from .BrowserClient import BrowserClient
+from .CustomSRP import CustomSRP
+from .Helpers import (
+    get_default_args,
+    process_args,
+    get_authentication_code,
+    choose_between_multiple_identitites,
+    generate_nem_login_parameters,
+)
+
+__version__ = "1.0.0"
+__author__ = "Hundter"
+__license__ = "MIT"
+
+__all__ = [
+    "BrowserClient",
+    "CustomSRP", 
+    "get_default_args",
+    "process_args",
+    "get_authentication_code",
+    "choose_between_multiple_identitites",
+    "generate_nem_login_parameters",
+]

--- a/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/login_flows/aula.py
+++ b/custom_components/aula_easyiq/aula_login_client/mitid_browserclient/login_flows/aula.py
@@ -1,0 +1,530 @@
+import requests, sys, logging
+from bs4 import BeautifulSoup
+import requests, json, base64, sys
+from urllib.parse import urlparse, parse_qs, urljoin
+
+sys.path.append("..")
+sys.path.append(".")
+from BrowserClient.Helpers import process_args, get_default_args
+from BrowserClient.Helpers import (
+    get_authentication_code,
+    process_args,
+    generate_nem_login_parameters,
+    get_default_args,
+    choose_between_multiple_identitites,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+argparser = get_default_args()
+args = argparser.parse_args()
+method, user_id, password, proxy = process_args(args)
+
+
+session = requests.Session()
+if proxy:
+    session.proxies.update({"http": f"socks5://{proxy}", "https": f"socks5://{proxy}"})
+
+# Step 1: GET the login page
+url1 = "https://login.aula.dk/auth/login.php?type=unilogin"
+# print(f"[DEBUG] GET {url1}")
+resp1 = session.get(url1)
+# print(f"[DEBUG] Response status: {resp1.status_code}")
+# print(f"[DEBUG] Response headers: {resp1.headers}")
+soup = BeautifulSoup(resp1.text, "html.parser")
+form = soup.find("form", {"action": True})
+if not form:
+    _LOGGER.error("Could not find login form.")
+    sys.exit(1)
+login_url = form["action"]
+# print(f"[DEBUG] Found login form action: {login_url}")
+
+# Step 2: POST to submit the MitID button
+post_data = {"selectedIdp": "nemlogin3"}
+# print(f"[DEBUG] POST {login_url} with data: {post_data}")
+resp2 = session.post(login_url, data=post_data, allow_redirects=False)
+# print(f"[DEBUG] Response status: {resp2.status_code}")
+# print(f"[DEBUG] Response headers: {resp2.headers}")
+
+# Step 3: GET the first redirect location
+if "Location" not in resp2.headers:
+    _LOGGER.error("[ERROR] No redirect after POST to login form.")
+    sys.exit(1)
+next_url = urljoin(resp2.url, resp2.headers["Location"])
+# print(f"[DEBUG] Redirect Location: {next_url}")
+# print(f"[DEBUG] GET {next_url}")
+resp3 = session.get(next_url, allow_redirects=False)
+# print(f"[DEBUG] Response status: {resp3.status_code}")
+# print(f"[DEBUG] Response headers: {resp3.headers}")
+
+# Step 4: GET the next redirect location
+if "Location" not in resp3.headers:
+    _LOGGER.error("[ERROR] No redirect after GET to first redirect location.")
+    sys.exit(1)
+next_url2 = urljoin(resp3.url, resp3.headers["Location"])
+# print(f"[DEBUG] Redirect Location: {next_url2}")
+# print(f"[DEBUG] GET {next_url2}")
+resp4 = session.get(next_url2, allow_redirects=False)
+# print(f"[DEBUG] Response status: {resp4.status_code}")
+# print(f"[DEBUG] Response headers: {resp4.headers}")
+
+# Step 5: GET the final redirect location
+if "Location" not in resp4.headers:
+    _LOGGER.error("[ERROR] No redirect after GET to second redirect location.")
+    sys.exit(1)
+next_url3 = urljoin(resp4.url, resp4.headers["Location"])
+# print(f"[DEBUG] Redirect Location: {next_url3}")
+# print(f"[DEBUG] GET {next_url3}")
+resp5 = session.get(next_url3, allow_redirects=False)
+# print(f"[DEBUG] Response status: {resp5.status_code}")
+# print(f"[DEBUG] Response headers: {resp5.headers}")
+
+# Step 6: Follow /login/mitid redirect if present
+if "Location" in resp5.headers:
+    next_url4 = urljoin(next_url3, resp5.headers["Location"])
+    #   print(f"[DEBUG] Redirect Location: {next_url4}")
+    #  print(f"[DEBUG] GET {next_url4}")
+    resp6 = session.get(next_url4, allow_redirects=False)
+    # print(f"[DEBUG] Response status: {resp6.status_code}")
+#   print(f"[DEBUG] Response headers: {resp6.headers}")
+# print(f"[DEBUG] Response body: {resp6.text}")
+else:
+    _LOGGER.debug(f"No further redirect. Final response body:")
+    # print(resp5.text)
+
+
+# Use the correct response for parsing the token
+final_html = resp6.text if "resp6" in locals() else resp5.text
+soup = BeautifulSoup(final_html, "lxml")
+token_input = soup.find("input", {"name": "__RequestVerificationToken"})
+
+if token_input:
+    request_verification_token = token_input.get("value")
+    _LOGGER.debug(f"__RequestVerificationToken: {request_verification_token}")
+
+    # Prepare dynamic POST data for /login/mitid/initialize
+    # You may need to adjust these fields based on the actual HTML and flow
+    post_url = "https://nemlog-in.mitid.dk/login/mitid/initialize"
+    post_headers = {
+        "accept": "*/*",
+        "accept-encoding": "gzip, deflate, br, zstd",
+        "accept-language": "en-US,en;q=0.9,da;q=0.8",
+        "cache-control": "no-cache",
+        "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "origin": "https://nemlog-in.mitid.dk",
+        "pragma": "no-cache",
+        "referer": "https://nemlog-in.mitid.dk/login/mitid",
+        "sec-ch-ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"',
+        "sec-fetch-dest": "empty",
+        "sec-fetch-mode": "cors",
+        "sec-fetch-site": "same-origin",
+        "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+        "x-requested-with": "XMLHttpRequest",
+    }
+
+    # Example form data, you may need to add more fields depending on the flow
+    post_data = {
+        "__RequestVerificationToken": request_verification_token
+        # Add other required fields here
+    }
+
+    # print(f"[DEBUG] POST {post_url} with data: {post_data}")
+    resp_init = session.post(post_url, headers=post_headers, data=post_data)
+    # print(f"[DEBUG] Response status: {resp_init.status_code}")
+    # print(f"[DEBUG] Response headers: {resp_init.headers}")
+    _LOGGER.debug(f"Response body: {resp_init.text}")
+
+    # Extract Aux value from JSON response
+    resp_init_json = resp_init.json()
+    if isinstance(resp_init_json, str):
+        resp_init_json = json.loads(resp_init_json)
+    aux_value = resp_init_json.get("Aux")
+    aux = json.loads(base64.b64decode(aux_value).decode())
+
+authorization_code = get_authentication_code(session, aux, method, user_id, password)
+_LOGGER.info(f"Your MitID authorization code was ({authorization_code})")
+
+
+session_storage_active_session_uuid = session.cookies.get("SessionUuid", "")
+session_storage_active_challenge = session.cookies.get("Challenge", "")
+
+params = {
+    "__RequestVerificationToken": request_verification_token,
+    "NewCulture": "",
+    "MitIDUseConfirmed": "True",
+    "MitIDAuthCode": authorization_code,
+    "MitIDAuthenticationCancelled": "",
+    "MitIDCoreClientError": "",
+    "SessionStorageActiveSessionUuid": session_storage_active_session_uuid,
+    "SessionStorageActiveChallenge": session_storage_active_challenge,
+}
+request = session.post("https://nemlog-in.mitid.dk/login/mitid", data=params)
+
+soup = BeautifulSoup(request.text, features="html.parser")
+
+# print(request.text)
+# User has more than one login option
+if request.url == "https://nemlog-in.mitid.dk/loginoption":
+    request, soup = choose_between_multiple_identitites(session, request, soup)
+
+relay_state = soup.find("input", {"name": "RelayState"}).get("value")
+saml_response = soup.find("input", {"name": "SAMLResponse"}).get("value")
+
+params = {"RelayState": relay_state, "SAMLResponse": saml_response}
+
+# Prepare headers for the SAML POST
+saml_post_headers = {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+    "accept-encoding": "gzip, deflate, br, zstd",
+    "accept-language": "en-US,en;q=0.9,da;q=0.8",
+    "cache-control": "max-age=0",
+    "content-type": "application/x-www-form-urlencoded",
+    "origin": "https://nemlog-in.mitid.dk",
+    "referer": "https://nemlog-in.mitid.dk/login/mitid",
+    "sec-ch-ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "cross-site",
+    "sec-fetch-user": "?1",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+}
+
+# Add cookies to the headers
+cookie_header = "; ".join([f"{c.name}={c.value}" for c in session.cookies])
+if cookie_header:
+    saml_post_headers["cookie"] = cookie_header
+
+# Make the POST request to broker endpoint (should return 302 redirect)
+request = session.post(
+    "https://broker.unilogin.dk/auth/realms/broker/broker/nemlogin3/endpoint",
+    data=params,
+    headers=saml_post_headers,
+    allow_redirects=False,  # Don't follow redirects automatically
+)
+
+_LOGGER.debug(f"Response Status: {request.status_code}")
+_LOGGER.debug(f"Response Headers: {dict(request.headers)}")
+
+# Extract the redirect location (action URL)
+
+action_url = request.headers["Location"]
+_LOGGER.debug(f"Extracted action URL: {action_url}")
+
+# Now follow the redirect to get the final form
+final_request = session.get(action_url)
+
+_LOGGER.debug(f"Final request status: {final_request.status_code}")
+_LOGGER.debug(f"Final response content length: {len(final_request.text)}")
+
+# Parse the response to extract form data and dynamic parameters
+soup = BeautifulSoup(final_request.text, "html.parser")
+
+# Extract dynamic parameters from the current URL or form
+parsed_url = urlparse(final_request.url)
+query_params = parse_qs(parsed_url.query)
+
+# Extract session_code, execution, client_id, and tab_id from the response or URL
+session_code = query_params.get("session_code", [""])[0]
+execution = query_params.get("execution", [""])[0]
+client_id = query_params.get("client_id", [""])[0]
+tab_id = query_params.get("tab_id", [""])[0]
+
+# If not found in URL, try to extract from form action or hidden inputs
+if not session_code or not execution:
+    form = soup.find("form")
+    if form:
+        form_action = form.get("action", "")
+
+        # Parse the form action URL to get the parameters
+        if form_action:
+            parsed_form_url = urlparse(form_action)
+            form_query_params = parse_qs(parsed_form_url.query)
+
+            if not session_code:
+                session_code = form_query_params.get("session_code", [""])[0]
+            if not execution:
+                execution = form_query_params.get("execution", [""])[0]
+            if not client_id:
+                client_id = form_query_params.get("client_id", [""])[0]
+            if not tab_id:
+                tab_id = form_query_params.get("tab_id", [""])[0]
+
+        # Also check hidden inputs as backup
+        for input_elem in form.find_all("input", type="hidden"):
+            name = input_elem.get("name", "")
+            value = input_elem.get("value", "")
+            if "session" in name.lower() and not session_code:
+                session_code = value
+            elif "execution" in name.lower() and not execution:
+                execution = value
+
+# Construct the post-broker-login URL
+post_broker_url = f"https://broker.unilogin.dk/auth/realms/broker/login-actions/post-broker-login?session_code={session_code}&execution={execution}&client_id={client_id}&tab_id={tab_id}"
+
+# Headers for the post-broker-login request
+post_broker_headers = {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+    "accept-encoding": "gzip, deflate, br, zstd",
+    "accept-language": "en-US,en;q=0.9,da;q=0.8",
+    "cache-control": "no-cache",
+    "connection": "keep-alive",
+    "content-length": "0",
+    "content-type": "application/x-www-form-urlencoded",
+    "host": "broker.unilogin.dk",
+    "origin": "null",
+    "pragma": "no-cache",
+    "referrer-policy": "no-referrer",
+    "sec-ch-ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "sec-fetch-dest": "document",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "same-origin",
+    "upgrade-insecure-requests": "1",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+}
+
+# Add existing cookies
+cookie_header = "; ".join([f"{c.name}={c.value}" for c in session.cookies])
+if cookie_header:
+    post_broker_headers["cookie"] = cookie_header
+
+_LOGGER.debug(f"Making POST request to: {post_broker_url}")
+
+# Make the POST request (expecting 302 redirect)
+post_broker_response = session.post(
+    post_broker_url,
+    headers=post_broker_headers,
+    data={},  # Empty form data as content-length is 0
+    allow_redirects=False,
+)
+
+_LOGGER.debug(f"Post-broker response status: {post_broker_response.status_code}")
+_LOGGER.debug(f"Post-broker response headers: {dict(post_broker_response.headers)}")
+
+# Check for redirect location
+if "Location" in post_broker_response.headers:
+    after_post_broker_url = post_broker_response.headers["Location"]
+    _LOGGER.debug(f"Redirect to after-post-broker-login URL: {after_post_broker_url}")
+
+    # Follow the redirect to the after-post-broker-login endpoint
+    after_response = session.get(after_post_broker_url)
+    _LOGGER.debug(f"After-post-broker response status: {after_response.status_code}")
+    _LOGGER.debug(
+        f"After-post-broker response content length: {len(after_response.text)}"
+    )
+
+    # Parse the response to extract SAML response and RelayState for Aula
+    after_soup = BeautifulSoup(after_response.text, "html.parser")
+
+    # Look for SAML response form
+    saml_form = after_soup.find("form")
+    if saml_form:
+        saml_response_input = saml_form.find("input", {"name": "SAMLResponse"})
+        relay_state_input = saml_form.find("input", {"name": "RelayState"})
+
+        if saml_response_input and relay_state_input:
+            final_saml_response = saml_response_input.get("value")
+            final_relay_state = relay_state_input.get("value")
+
+            # Prepare headers for the final SAML POST to Aula
+            aula_saml_headers = {
+                "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                "accept-encoding": "gzip, deflate, br, zstd",
+                "accept-language": "en-US,en;q=0.9,da;q=0.8",
+                "cache-control": "no-cache",
+                "content-type": "application/x-www-form-urlencoded",
+                "origin": "null",
+                "pragma": "no-cache",
+                "priority": "u=0, i",
+                "sec-ch-ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+                "sec-ch-ua-mobile": "?0",
+                "sec-ch-ua-platform": '"Windows"',
+                "sec-fetch-dest": "document",
+                "sec-fetch-mode": "navigate",
+                "sec-fetch-site": "cross-site",
+                "upgrade-insecure-requests": "1",
+                "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+            }
+
+            # Add cookies for Aula request
+            aula_cookie_header = "; ".join(
+                [
+                    f"{c.name}={c.value}"
+                    for c in session.cookies
+                    if "aula.dk" in c.domain or c.domain == ""
+                ]
+            )
+            if aula_cookie_header:
+                aula_saml_headers["cookie"] = aula_cookie_header
+
+            # Prepare the SAML POST data
+            aula_saml_data = {
+                "SAMLResponse": final_saml_response,
+                "RelayState": final_relay_state,
+            }
+
+            _LOGGER.debug(f"Making final SAML POST to Aula...")
+
+            # Make the final POST request to Aula (expecting 303 redirect)
+            aula_response = session.post(
+                "https://login.aula.dk/simplesaml/module.php/saml/sp/saml2-acs.php/uni-sp",
+                headers=aula_saml_headers,
+                data=aula_saml_data,
+                allow_redirects=False,
+            )
+
+            _LOGGER.debug(
+                f"Aula SAML POST response status: {aula_response.status_code}"
+            )
+            _LOGGER.debug(
+                f"Aula SAML POST response headers: {dict(aula_response.headers)}"
+            )
+
+            # Check for final redirect to Aula login
+            if "Location" in aula_response.headers:
+                final_aula_url = aula_response.headers["Location"]
+                _LOGGER.debug(f"Final Aula redirect URL: {final_aula_url}")
+
+                # Follow the final redirect
+                final_aula_response = session.get(final_aula_url)
+                _LOGGER.debug(
+                    f"Final Aula response status: {final_aula_response.status_code}"
+                )
+                _LOGGER.debug(
+                    f"Final Aula response content length: {len(final_aula_response.text)}"
+                )
+                _LOGGER.debug(f"Final Aula response URL: {final_aula_response.url}")
+
+                if "login" in final_aula_response.url.lower():
+                    # Check if we're back at the login page or if this is a success redirect
+                    if (
+                        final_aula_response.url
+                        == "https://login.aula.dk/auth/login.php?type=unilogin"
+                    ):
+                        _LOGGER.warning(
+                            "Redirected back to login page - authentication may have failed or requires additional steps"
+                        )
+                    else:
+                        _LOGGER.info(
+                            "Successfully completed authentication flow - redirected to Aula login page"
+                        )
+                else:
+                    _LOGGER.info(
+                        "Authentication completed - redirected to Aula dashboard or other page"
+                    )
+                    _LOGGER.debug(f"Final URL: {final_aula_response.url}")
+
+                    # If we successfully reached the portal, make API call to get profiles
+                    if "portal" in final_aula_response.url.lower():
+                        _LOGGER.debug("Making API request to get user profiles...")
+
+                        # Extract CSRF token and other necessary data from the portal page
+                        portal_soup = BeautifulSoup(
+                            final_aula_response.text, "html.parser"
+                        )
+                        csrf_token = None
+
+                        # Look for CSRF token in meta tags or script tags
+                        csrf_meta = portal_soup.find("meta", {"name": "csrf-token"})
+                        if csrf_meta:
+                            csrf_token = csrf_meta.get("content")
+
+                        # Prepare headers for the API request
+                        api_headers = {
+                            "accept": "application/json, text/plain, */*",
+                            "accept-encoding": "gzip, deflate, br, zstd",
+                            "accept-language": "en-US,en;q=0.9,da;q=0.8",
+                            "cache-control": "no-cache",
+                            "pragma": "no-cache",
+                            "priority": "u=1, i",
+                            "referer": "https://www.aula.dk/portal/",
+                            "sec-ch-ua": '"Not;A=Brand";v="99", "Google Chrome";v="139", "Chromium";v="139"',
+                            "sec-ch-ua-mobile": "?0",
+                            "sec-ch-ua-platform": '"Windows"',
+                            "sec-fetch-dest": "empty",
+                            "sec-fetch-mode": "cors",
+                            "sec-fetch-site": "same-origin",
+                            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36",
+                        }
+
+                        # Add cookies for the API request
+                        api_cookie_header = "; ".join(
+                            [
+                                f"{c.name}={c.value}"
+                                for c in session.cookies
+                                if "aula.dk" in c.domain or c.domain == ""
+                            ]
+                        )
+                        if csrf_token:
+                            api_cookie_header += f"; Csrfp-Token={csrf_token}"
+                        if api_cookie_header:
+                            api_headers["cookie"] = api_cookie_header
+
+                        # Make the API request to get profiles
+                        api_response = session.get(
+                            "https://www.aula.dk/api/v22/?method=profiles.getProfilesByLogin",
+                            headers=api_headers,
+                        )
+
+                        _LOGGER.debug(
+                            f"API response status: {api_response.status_code}"
+                        )
+                        _LOGGER.debug(
+                            f"API response headers: {dict(api_response.headers)}"
+                        )
+
+                        if api_response.status_code == 200:
+                            try:
+                                profiles_data = api_response.json()
+                                _LOGGER.info(f"Successfully retrieved profiles data:")
+                                _LOGGER.debug(f"Raw JSON response: {profiles_data}")
+
+                                # Try different possible data structures
+                                if "data" in profiles_data:
+                                    data = profiles_data["data"]
+                                    if "profiles" in data:
+                                        profiles = data["profiles"]
+                                        _LOGGER.info(
+                                            f"Number of profiles: {len(profiles)}"
+                                        )
+                                        for profile in profiles:
+                                            _LOGGER.info(
+                                                f"Profile: {profile.get('name', 'Unknown')} - ID: {profile.get('id', 'Unknown')}"
+                                            )
+                                    else:
+                                        _LOGGER.debug(
+                                            f"Available data keys: {list(data.keys())}"
+                                        )
+                                else:
+                                    _LOGGER.debug(
+                                        f"Available top-level keys: {list(profiles_data.keys())}"
+                                    )
+
+                            except Exception as e:
+                                _LOGGER.error(f"Error parsing profiles JSON: {e}")
+                                _LOGGER.debug(
+                                    f"Raw response: {api_response.text[:500]}..."
+                                )
+                        else:
+                            _LOGGER.error(
+                                f"API request failed with status {api_response.status_code}"
+                            )
+                            _LOGGER.debug(
+                                f"Response content: {api_response.text[:500]}..."
+                            )
+            else:
+                _LOGGER.error("No final redirect found in Aula SAML response")
+        else:
+            _LOGGER.error(
+                "Could not find SAMLResponse or RelayState in after-post-broker response"
+            )
+    else:
+        _LOGGER.error("No SAML form found in after-post-broker response")
+else:
+    _LOGGER.error("No redirect location found in post-broker-login response")

--- a/custom_components/aula_easyiq/client.py
+++ b/custom_components/aula_easyiq/client.py
@@ -1,9 +1,10 @@
-"""EasyIQ API client with working CalendarGetWeekplanEvents implementation."""
+"""EasyIQ API client with MitID authentication and CalendarGetWeekplanEvents implementation."""
 from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+import threading
+from typing import Any, Callable
 import datetime
 import json
 
@@ -56,6 +57,7 @@ try:
         EASYIQ_HOMEWORK_WIDGET_ID,
         EASYIQ_WIDGETS,
         PRESENCE_STATUS,
+        AUTH_METHOD_APP,
     )
 except ImportError:
     # For standalone testing
@@ -77,21 +79,73 @@ except ImportError:
         5: "SOVER",            # Sleeping
         8: "HENTET/GÅET",      # Picked up/Gone
     }
+    AUTH_METHOD_APP = "APP"
+
+try:
+    from .aula_login_client.client import AulaLoginClient
+    from .aula_login_client.exceptions import AulaAuthenticationError
+except ImportError:
+    AulaLoginClient = None  # type: ignore[assignment]
+    AulaAuthenticationError = Exception  # type: ignore[assignment,misc]
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class EasyIQClient:
-    """Client for communicating with EasyIQ API using the working CalendarGetWeekplanEvents approach."""
+    """Client for communicating with EasyIQ + Aula APIs using MitID authentication."""
 
-    def __init__(self, username: str, password: str) -> None:
+    def __init__(
+        self,
+        mitid_username: str,
+        auth_method: str = AUTH_METHOD_APP,
+        mitid_password: str | None = None,
+        mitid_token: str | None = None,
+        mitid_identity: int = 1,
+        stored_tokens: dict | None = None,
+        identity_selector: Callable | None = None,
+        token_update_callback: Callable[[dict], None] | None = None,
+    ) -> None:
         """Initialize the client."""
-        self.username = username
-        self.password = password
+        self.mitid_username = mitid_username
+        self.auth_method = auth_method
+        self.mitid_password = mitid_password
+        self.mitid_token = mitid_token
+        self.mitid_identity = mitid_identity
+
+        # Backwards-compatibility shim: a few helpers still emit `x-login: <username>`
+        # against EasyIQ's widget endpoint. The MitID username is the right value.
+        self.username = mitid_username
+
         self.session: aiohttp.ClientSession | None = None
-        self._session: requests.Session | None = None  # Synchronous session for auth
+        self._session: requests.Session | None = None  # Synchronous HTTP session for API calls
         self._authenticated = False
-        
+
+        # OAuth tokens issued by AulaLoginClient (access_token, refresh_token, expires_at, ...)
+        self._tokens: dict = dict(stored_tokens) if stored_tokens else {}
+        self._token_update_callback = token_update_callback
+        self._token_refresh_lock = threading.Lock()
+
+        # AulaLoginClient owns the MitID/OAuth flow and refresh logic.
+        self._aula_client = None
+        if AulaLoginClient is not None:
+            self._aula_client = AulaLoginClient(
+                mitid_username=mitid_username,
+                mitid_password=mitid_password,
+                mitid_token=mitid_token,
+                auth_method=auth_method,
+                verbose=False,
+                debug=False,
+            )
+            if identity_selector is None:
+                def _default_identity_selector(identity_names):
+                    if self.mitid_identity <= len(identity_names):
+                        return str(self.mitid_identity)
+                    return "1"
+                identity_selector = _default_identity_selector
+            self._aula_client.identity_selector = identity_selector
+            if self._tokens:
+                self._aula_client.tokens = self._tokens
+
         # Authentication data
         self._profiles = []
         self._profile_context = []
@@ -101,7 +155,7 @@ class EasyIQClient:
         self.apiurl = ""  # For compatibility with Aula client
         self.widgets = {}
         self.tokens = {}
-        
+
         # Data storage
         self.children = []
         self._childuserids = []
@@ -113,6 +167,50 @@ class EasyIQClient:
         self.homework_data = {}
         self.presence_status = {}  # Stores presence status codes (0-8)
         self.presence_data = {}    # Stores detailed presence information
+
+    def _get_access_token_param(self) -> str:
+        """Return the access_token query string fragment, or empty string."""
+        if self._tokens and self._tokens.get("access_token"):
+            return "&access_token=" + self._tokens["access_token"]
+        return ""
+
+    def _persist_tokens(self) -> None:
+        """Notify the integration that tokens were refreshed so they can be saved."""
+        if self._token_update_callback and self._tokens:
+            try:
+                self._token_update_callback(dict(self._tokens))
+            except Exception as err:  # pragma: no cover - persistence is best-effort
+                _LOGGER.warning("Token persistence callback failed: %s", err)
+
+    def _ensure_valid_token(self) -> bool:
+        """Refresh the access token if it is expired. Returns True if usable."""
+        if not self._aula_client or not self._tokens:
+            return bool(self._tokens.get("access_token"))
+
+        try:
+            self._aula_client.tokens = self._tokens
+            check = self._aula_client.check_token_expiration()
+        except Exception as err:
+            _LOGGER.debug("Token expiration check failed: %s - assuming valid", err)
+            return True
+
+        if check.get("valid"):
+            return True
+
+        # Need a refresh - serialize concurrent attempts.
+        if not self._token_refresh_lock.acquire(blocking=False):
+            _LOGGER.debug("Token refresh already in progress, continuing")
+            return True
+        try:
+            if self._aula_client.renew_access_token():
+                self._tokens = self._aula_client.tokens
+                self._persist_tokens()
+                _LOGGER.info("Aula access token refreshed via refresh_token")
+                return True
+            _LOGGER.warning("Refresh token rejected; re-authentication required")
+            return False
+        finally:
+            self._token_refresh_lock.release()
 
     async def _ensure_session(self) -> aiohttp.ClientSession:
         """Ensure we have an active aiohttp session."""
@@ -133,115 +231,106 @@ class EasyIQClient:
             await self.session.close()
 
     def login(self) -> bool:
-        """Login using the proven working Aula authentication approach."""
-        if requests is None or BS4 is None:
-            _LOGGER.error("requests or BeautifulSoup not available - cannot authenticate")
+        """Authenticate with Aula via MitID OAuth and verify API access."""
+        if requests is None:
+            _LOGGER.error("requests not available - cannot authenticate")
             return False
-        
+        if self._aula_client is None:
+            _LOGGER.error(
+                "aula_login_client package not available - cannot authenticate. "
+                "Make sure pycryptodome and qrcode are installed."
+            )
+            return False
+
         try:
-            _LOGGER.debug("Logging in")
+            # Reuse stored tokens if possible - falls back to refresh, then full MitID flow.
+            need_fresh_auth = True
+            if self._tokens.get("access_token"):
+                self._aula_client.tokens = self._tokens
+                check = self._aula_client.check_token_expiration()
+                if check.get("valid"):
+                    _LOGGER.info("Using stored Aula access token")
+                    need_fresh_auth = False
+                else:
+                    _LOGGER.info(
+                        "Stored token not valid (%s); attempting refresh",
+                        check.get("reason", "expired"),
+                    )
+                    if self._aula_client.renew_access_token():
+                        self._tokens = self._aula_client.tokens
+                        self._persist_tokens()
+                        need_fresh_auth = False
+
+            if need_fresh_auth:
+                _LOGGER.info("Performing fresh MitID authentication for %s", self.mitid_username)
+                auth_result = self._aula_client.authenticate()
+                if not auth_result.get("success"):
+                    err = auth_result.get("error", "unknown error")
+                    _LOGGER.error("MitID authentication failed: %s", err)
+                    return False
+                self._tokens = auth_result["tokens"]
+                self._persist_tokens()
+
+            # Initialize the HTTP session used for all subsequent API calls.
             self._session = requests.Session()
-            
-            # Step 1: Get initial login page (simplified approach from working Aula client)
-            headers = {
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-                "Accept-Language": "da,en-US;q=0.7,en;q=0.3",
-                "DNT": "1",
-                "Upgrade-Insecure-Requests": "1",
-                "Sec-Fetch-Dest": "document",
-                "Sec-Fetch-Mode": "navigate",
-                "Sec-Fetch-Site": "none",
-                "Sec-Fetch-User": "?1",
-            }
-            params = {"type": "unilogin"}
-            response = self._session.get(
-                "https://login.aula.dk/auth/login.php",
-                params=params,
-                headers=headers,
-                verify=True,
+            self._session.headers.update(
+                {
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) "
+                        "Gecko/20100101 Firefox/115.0"
+                    ),
+                }
             )
 
-            _html = BS4(response.text, "lxml")
-            _url = _html.form["action"]
-            
-            # Step 2: Submit IdP selection (simplified)
-            headers = {
-                "Host": "broker.unilogin.dk",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-                "Accept-Language": "da,en-US;q=0.7,en;q=0.3",
-                "Content-Type": "application/x-www-form-urlencoded",
-                "Origin": "null",
-                "DNT": "1",
-                "Upgrade-Insecure-Requests": "1",
-                "Sec-Fetch-Dest": "document",
-                "Sec-Fetch-Mode": "navigate",
-                "Sec-Fetch-Site": "same-origin",
-                "Sec-Fetch-User": "?1",
-            }
-            data = {"selectedIdp": "uni_idp"}
-            response = self._session.post(_url, headers=headers, data=data, verify=True)
-
-            # Step 3: Complete authentication flow (simplified from working Aula client)
-            user_data = {
-                "username": self.username,
-                "password": self.password,
-                "selected-aktoer": "KONTAKT",
-            }
-            redirects = 0
-            success = False
-            url = ""
-            while success == False and redirects < 10:
-                html = BS4(response.text, "lxml")
-                url = html.form["action"]
-
-                post_data = {}
-                for input_elem in html.find_all("input"):
-                    if input_elem.has_attr("name") and input_elem.has_attr("value"):
-                        post_data[input_elem["name"]] = input_elem["value"]
-                        for key in user_data:
-                            if input_elem.has_attr("name") and input_elem["name"] == key:
-                                post_data[key] = user_data[key]
-
-                response = self._session.post(url, data=post_data, verify=True)
-                if response.url == "https://www.aula.dk:443/portal/":
-                    success = True
-                redirects += 1
-
-            if not success:
-                _LOGGER.error(f"Authentication failed after {redirects} redirects")
-                return False
-
-            # Step 4: Find and validate API version
+            # Find and validate API version. Aula expects access_token as a query param,
+            # not a Bearer header (the Bearer header is only for EasyIQ widget calls).
             self.apiurl = API + API_VERSION
             self.api_url = self.apiurl
             apiver = int(API_VERSION)
             api_success = False
-            while api_success == False:
+            max_attempts = 20
+            attempt = 0
+            while not api_success and attempt < max_attempts:
+                attempt += 1
                 _LOGGER.debug("Trying API at " + self.apiurl)
                 ver = self._session.get(
-                    self.apiurl + "?method=profiles.getProfilesByLogin", verify=True
+                    self.apiurl
+                    + "?method=profiles.getProfilesByLogin"
+                    + self._get_access_token_param(),
+                    verify=True,
                 )
                 if ver.status_code == 410:
                     _LOGGER.debug(
-                        "API was expected at "
-                        + self.apiurl
-                        + " but responded with HTTP 410. The integration will automatically try a newer version and everything may work fine."
+                        "API was expected at %s but responded with HTTP 410. "
+                        "Trying a newer version.",
+                        self.apiurl,
                     )
                     apiver += 1
+                    self.apiurl = API + str(apiver)
+                    self.api_url = self.apiurl
                 elif ver.status_code == 403:
-                    _LOGGER.error("Access denied - check credentials")
+                    _LOGGER.error("Access denied - token may be invalid")
                     return False
                 elif ver.status_code == 200:
                     ver_json = ver.json()
+                    if not ver_json.get("data") or "profiles" not in ver_json["data"]:
+                        _LOGGER.error("API returned 200 but no profile data")
+                        return False
                     self._profiles = ver_json["data"]["profiles"]
                     api_success = True
-                self.apiurl = API + str(apiver)
-                self.api_url = self.apiurl
+                else:
+                    _LOGGER.error("Unexpected API response: %s", ver.status_code)
+                    return False
+            if not api_success:
+                _LOGGER.error("Could not find a working Aula API version")
+                return False
             _LOGGER.debug("Found API on " + self.apiurl)
 
-            # Step 5: Get profile context and children
+            # Get profile context and children
             profile_response = self._session.get(
-                self.apiurl + "?method=profiles.getProfileContext&portalrole=guardian",
+                self.apiurl
+                + "?method=profiles.getProfileContext&portalrole=guardian"
+                + self._get_access_token_param(),
                 verify=True,
             )
             profile_json = profile_response.json()
@@ -304,8 +393,12 @@ class EasyIQClient:
             return {}
         
         try:
+            self._ensure_valid_token()
             response = self._session.get(
-                self.apiurl + "?method=aulaToken.getWidgets", verify=True
+                self.apiurl
+                + "?method=aulaToken.getWidgets"
+                + self._get_access_token_param(),
+                verify=True,
             )
             if response.status_code == 200:
                 widgets_json = response.json()
@@ -345,8 +438,11 @@ class EasyIQClient:
         
         _LOGGER.debug(f"Requesting new token for widget {widget_id}")
         try:
+            self._ensure_valid_token()
             response = self._session.get(
-                self.apiurl + f"?method=aulaToken.getAulaToken&widgetId={widget_id}",
+                self.apiurl
+                + f"?method=aulaToken.getAulaToken&widgetId={widget_id}"
+                + self._get_access_token_param(),
                 verify=True,
             )
             if response.status_code == 200:
@@ -709,8 +805,11 @@ class EasyIQClient:
         try:
             # Get message threads from Aula API
             _LOGGER.debug("Fetching message threads...")
+            self._ensure_valid_token()
             mesres = self._session.get(
-                self.apiurl + "?method=messaging.getThreads&sortOn=date&orderDirection=desc&page=0",
+                self.apiurl
+                + "?method=messaging.getThreads&sortOn=date&orderDirection=desc&page=0"
+                + self._get_access_token_param(),
                 verify=True,
             )
             
@@ -742,7 +841,9 @@ class EasyIQClient:
             if unread == 1 and threadid:
                 _LOGGER.debug(f"Fetching message content for thread: {threadid}")
                 threadres = self._session.get(
-                    self.apiurl + f"?method=messaging.getMessagesForThread&threadId={threadid}&page=0",
+                    self.apiurl
+                    + f"?method=messaging.getMessagesForThread&threadId={threadid}&page=0"
+                    + self._get_access_token_param(),
                     verify=True,
                 )
                 
@@ -819,16 +920,20 @@ class EasyIQClient:
             actual_child_id = child_data.get("id", child_id)
             _LOGGER.debug(f"Child {child_id} -> using actual_child_id: {actual_child_id} for presence API call")
             
-            # Use the proper presence API endpoint
-            url = f"{API}{API_VERSION}/"
+            # Use the proper presence API endpoint. Aula expects the access_token
+            # as a query parameter; we live on whichever apiurl version login() found.
+            url = self.apiurl if self.apiurl else f"{API}{API_VERSION}"
             params = {
                 "method": "presence.getDailyOverview",
-                f"childIds[]": actual_child_id
+                f"childIds[]": actual_child_id,
             }
-            
+            self._ensure_valid_token()
+            if self._tokens.get("access_token"):
+                params["access_token"] = self._tokens["access_token"]
+
             _LOGGER.debug("Fetching presence data for child %s (actual ID: %s)", child_id, actual_child_id)
-            
-            # Use synchronous session in thread pool to maintain authentication cookies
+
+            # Use synchronous session in thread pool to keep coordinator non-blocking.
             import asyncio
             loop = asyncio.get_event_loop()
             response = await loop.run_in_executor(

--- a/custom_components/aula_easyiq/client.py
+++ b/custom_components/aula_easyiq/client.py
@@ -174,6 +174,14 @@ class EasyIQClient:
             return "&access_token=" + self._tokens["access_token"]
         return ""
 
+    def _aula_get(self, method: str, **extra_params: str) -> "requests.Response":
+        """GET https://www.aula.dk/api/v<n>/?method=...&access_token=...&extras."""
+        self._ensure_valid_token()
+        url = f"{self.apiurl}?method={method}{self._get_access_token_param()}"
+        for key, value in extra_params.items():
+            url += f"&{key}={value}"
+        return self._session.get(url, verify=True)
+
     def _persist_tokens(self) -> None:
         """Notify the integration that tokens were refreshed so they can be saved."""
         if self._token_update_callback and self._tokens:
@@ -187,6 +195,14 @@ class EasyIQClient:
         if not self._aula_client or not self._tokens:
             return bool(self._tokens.get("access_token"))
 
+        # Fast path: skip the JWT decode if we already know expires_at and have
+        # > 5 minutes left. check_token_expiration() is hit thousands of times
+        # per day across all the API calls, so the early-out matters.
+        import time
+        expires_at = self._tokens.get("expires_at")
+        if isinstance(expires_at, (int, float)) and expires_at - time.time() > 300:
+            return True
+
         try:
             self._aula_client.tokens = self._tokens
             check = self._aula_client.check_token_expiration()
@@ -197,7 +213,6 @@ class EasyIQClient:
         if check.get("valid"):
             return True
 
-        # Need a refresh - serialize concurrent attempts.
         if not self._token_refresh_lock.acquire(blocking=False):
             _LOGGER.debug("Token refresh already in progress, continuing")
             return True
@@ -243,7 +258,6 @@ class EasyIQClient:
             return False
 
         try:
-            # Reuse stored tokens if possible - falls back to refresh, then full MitID flow.
             need_fresh_auth = True
             if self._tokens.get("access_token"):
                 self._aula_client.tokens = self._tokens
@@ -271,7 +285,6 @@ class EasyIQClient:
                 self._tokens = auth_result["tokens"]
                 self._persist_tokens()
 
-            # Initialize the HTTP session used for all subsequent API calls.
             self._session = requests.Session()
             self._session.headers.update(
                 {
@@ -282,56 +295,40 @@ class EasyIQClient:
                 }
             )
 
-            # Find and validate API version. Aula expects access_token as a query param,
-            # not a Bearer header (the Bearer header is only for EasyIQ widget calls).
+            # Aula expects access_token as a query param, not a Bearer header
+            # (Bearer is reserved for EasyIQ widget calls).
             self.apiurl = API + API_VERSION
             self.api_url = self.apiurl
             apiver = int(API_VERSION)
             api_success = False
-            max_attempts = 20
-            attempt = 0
-            while not api_success and attempt < max_attempts:
-                attempt += 1
+            for _ in range(20):
                 _LOGGER.debug("Trying API at " + self.apiurl)
-                ver = self._session.get(
-                    self.apiurl
-                    + "?method=profiles.getProfilesByLogin"
-                    + self._get_access_token_param(),
-                    verify=True,
-                )
+                ver = self._aula_get("profiles.getProfilesByLogin")
                 if ver.status_code == 410:
-                    _LOGGER.debug(
-                        "API was expected at %s but responded with HTTP 410. "
-                        "Trying a newer version.",
-                        self.apiurl,
-                    )
                     apiver += 1
                     self.apiurl = API + str(apiver)
                     self.api_url = self.apiurl
-                elif ver.status_code == 403:
+                    continue
+                if ver.status_code == 403:
                     _LOGGER.error("Access denied - token may be invalid")
                     return False
-                elif ver.status_code == 200:
+                if ver.status_code == 200:
                     ver_json = ver.json()
                     if not ver_json.get("data") or "profiles" not in ver_json["data"]:
                         _LOGGER.error("API returned 200 but no profile data")
                         return False
                     self._profiles = ver_json["data"]["profiles"]
                     api_success = True
-                else:
-                    _LOGGER.error("Unexpected API response: %s", ver.status_code)
-                    return False
+                    break
+                _LOGGER.error("Unexpected API response: %s", ver.status_code)
+                return False
             if not api_success:
                 _LOGGER.error("Could not find a working Aula API version")
                 return False
             _LOGGER.debug("Found API on " + self.apiurl)
 
-            # Get profile context and children
-            profile_response = self._session.get(
-                self.apiurl
-                + "?method=profiles.getProfileContext&portalrole=guardian"
-                + self._get_access_token_param(),
-                verify=True,
+            profile_response = self._aula_get(
+                "profiles.getProfileContext", portalrole="guardian"
             )
             profile_json = profile_response.json()
             self._profilecontext = profile_json["data"]["institutionProfile"]["relations"]
@@ -393,13 +390,7 @@ class EasyIQClient:
             return {}
         
         try:
-            self._ensure_valid_token()
-            response = self._session.get(
-                self.apiurl
-                + "?method=aulaToken.getWidgets"
-                + self._get_access_token_param(),
-                verify=True,
-            )
+            response = self._aula_get("aulaToken.getWidgets")
             if response.status_code == 200:
                 widgets_json = response.json()
                 widgets_data = widgets_json.get("data", {})
@@ -438,13 +429,7 @@ class EasyIQClient:
         
         _LOGGER.debug(f"Requesting new token for widget {widget_id}")
         try:
-            self._ensure_valid_token()
-            response = self._session.get(
-                self.apiurl
-                + f"?method=aulaToken.getAulaToken&widgetId={widget_id}"
-                + self._get_access_token_param(),
-                verify=True,
-            )
+            response = self._aula_get("aulaToken.getAulaToken", widgetId=widget_id)
             if response.status_code == 200:
                 response_json = response.json()
                 bearer_token = response_json["data"]
@@ -803,14 +788,12 @@ class EasyIQClient:
     def _sync_get_messages(self) -> dict[str, Any]:
         """Synchronous version of messages retrieval."""
         try:
-            # Get message threads from Aula API
             _LOGGER.debug("Fetching message threads...")
-            self._ensure_valid_token()
-            mesres = self._session.get(
-                self.apiurl
-                + "?method=messaging.getThreads&sortOn=date&orderDirection=desc&page=0"
-                + self._get_access_token_param(),
-                verify=True,
+            mesres = self._aula_get(
+                "messaging.getThreads",
+                sortOn="date",
+                orderDirection="desc",
+                page="0",
             )
             
             if mesres.status_code != 200:
@@ -840,11 +823,10 @@ class EasyIQClient:
             # If we have an unread message, get its content
             if unread == 1 and threadid:
                 _LOGGER.debug(f"Fetching message content for thread: {threadid}")
-                threadres = self._session.get(
-                    self.apiurl
-                    + f"?method=messaging.getMessagesForThread&threadId={threadid}&page=0"
-                    + self._get_access_token_param(),
-                    verify=True,
+                threadres = self._aula_get(
+                    "messaging.getMessagesForThread",
+                    threadId=str(threadid),
+                    page="0",
                 )
                 
                 if threadres.status_code == 200:

--- a/custom_components/aula_easyiq/config_flow.py
+++ b/custom_components/aula_easyiq/config_flow.py
@@ -1,6 +1,8 @@
-"""Config flow for EasyIQ integration."""
+"""Config flow for the EasyIQ integration (MitID)."""
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
 import logging
 from typing import Any
 
@@ -11,35 +13,53 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
+from .aula_login_client.client import AulaLoginClient
 from .const import (
-    CONF_PASSWORD,
-    CONF_USERNAME,
-    CONF_SCHOOLSCHEDULE,
-    CONF_WEEKPLAN,
+    AUTH_METHOD_APP,
+    AUTH_METHOD_TOKEN,
+    CONF_ACCESS_TOKEN,
+    CONF_AUTH_METHOD,
     CONF_HOMEWORK,
-    CONF_PRESENCE,
-    CONF_WEEKPLAN_INTERVAL,
-    CONF_HOMEWORK_INTERVAL,
-    CONF_PRESENCE_INTERVAL,
-    CONF_MESSAGES_INTERVAL,
-    CONF_WEEKPLAN_DAYS,
     CONF_HOMEWORK_DAYS,
-    DEFAULT_WEEKPLAN_INTERVAL,
-    DEFAULT_HOMEWORK_INTERVAL,
-    DEFAULT_PRESENCE_INTERVAL,
-    DEFAULT_MESSAGES_INTERVAL,
-    DEFAULT_WEEKPLAN_DAYS,
+    CONF_HOMEWORK_INTERVAL,
+    CONF_MESSAGES_INTERVAL,
+    CONF_MITID_IDENTITY,
+    CONF_MITID_PASSWORD,
+    CONF_MITID_TOKEN,
+    CONF_MITID_USE_TOKEN,
+    CONF_MITID_USERNAME,
+    CONF_PRESENCE,
+    CONF_PRESENCE_INTERVAL,
+    CONF_REFRESH_TOKEN,
+    CONF_SCHOOLSCHEDULE,
+    CONF_TOKEN_EXPIRES_AT,
+    CONF_WEEKPLAN,
+    CONF_WEEKPLAN_DAYS,
+    CONF_WEEKPLAN_INTERVAL,
     DEFAULT_HOMEWORK_DAYS,
+    DEFAULT_HOMEWORK_INTERVAL,
+    DEFAULT_MESSAGES_INTERVAL,
+    DEFAULT_PRESENCE_INTERVAL,
+    DEFAULT_WEEKPLAN_DAYS,
+    DEFAULT_WEEKPLAN_INTERVAL,
     DOMAIN,
+)
+from .views import (
+    EasyIQAuthSelectIdentityView,
+    EasyIQAuthStatusView,
+    EasyIQAuthView,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-# Schema for user input
-STEP_USER_DATA_SCHEMA = vol.Schema(
+
+USER_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_MITID_USERNAME): str,
+        vol.Optional(CONF_MITID_USE_TOKEN, default=False): bool,
+        vol.Optional(CONF_MITID_IDENTITY, default=1): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=10)
+        ),
         vol.Optional(CONF_SCHOOLSCHEDULE, default=True): bool,
         vol.Optional(CONF_WEEKPLAN, default=True): bool,
         vol.Optional(CONF_HOMEWORK, default=True): bool,
@@ -48,76 +68,300 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
-async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-    """
-    # Basic validation - check that username and password are provided
-    username = data.get(CONF_USERNAME)
-    password = data.get(CONF_PASSWORD)
-    
-    if not username or not password:
-        raise InvalidAuth("Username and password are required")
-    
-    # For production use, this could validate credentials against the EasyIQ API
-    # Currently we rely on runtime authentication validation in the client
-    
-    # Return info that you want to store in the config entry.
-    return {"title": f"EasyIQ ({username})"}
+TOKEN_CREDENTIALS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MITID_PASSWORD): str,
+        vol.Required(CONF_MITID_TOKEN): str,
+    }
+)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for EasyIQ."""
+    """Handle the EasyIQ MitID config flow."""
 
-    VERSION = 1
+    VERSION = 2
+
+    def __init__(self) -> None:
+        self._mitid_username: str | None = None
+        self._auth_method: str = AUTH_METHOD_APP
+        self._mitid_password: str | None = None
+        self._mitid_token: str | None = None
+        self._mitid_identity: int = 1
+        self._feature_flags: dict[str, Any] = {}
+        self._auth_client: AulaLoginClient | None = None
+        self._tokens: dict | None = None
+        self._reauth_entry: config_entries.ConfigEntry | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
+        """Collect MitID username + feature flags."""
+        if user_input is not None:
+            self._mitid_username = user_input[CONF_MITID_USERNAME]
+            use_token = user_input.get(CONF_MITID_USE_TOKEN, False)
+            self._auth_method = AUTH_METHOD_TOKEN if use_token else AUTH_METHOD_APP
+            self._mitid_identity = user_input.get(CONF_MITID_IDENTITY, 1)
+            self._feature_flags = {
+                CONF_SCHOOLSCHEDULE: user_input.get(CONF_SCHOOLSCHEDULE, True),
+                CONF_WEEKPLAN: user_input.get(CONF_WEEKPLAN, True),
+                CONF_HOMEWORK: user_input.get(CONF_HOMEWORK, True),
+                CONF_PRESENCE: user_input.get(CONF_PRESENCE, True),
+                CONF_MITID_USE_TOKEN: use_token,
+                CONF_MITID_IDENTITY: self._mitid_identity,
+            }
 
-        errors = {}
+            if use_token:
+                return await self.async_step_token_credentials()
+            return await self.async_step_authenticate()
 
-        try:
-            info = await validate_input(self.hass, user_input)
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
-        except InvalidAuth:
-            errors["base"] = "invalid_auth"
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-        else:
-            return self.async_create_entry(title=info["title"], data=user_input)
+        return self.async_show_form(step_id="user", data_schema=USER_SCHEMA)
+
+    async def async_step_token_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Collect MitID password + 6-digit code from a code reader (TOKEN method)."""
+        if user_input is not None:
+            self._mitid_password = user_input[CONF_MITID_PASSWORD]
+            self._mitid_token = user_input[CONF_MITID_TOKEN]
+            return await self.async_step_authenticate()
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="token_credentials", data_schema=TOKEN_CREDENTIALS_SCHEMA
+        )
+
+    async def async_step_authenticate(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Run the actual MitID OAuth flow, surfacing QR codes via a web view."""
+        session_data = None
+        if (
+            DOMAIN in self.hass.data
+            and "auth_sessions" in self.hass.data[DOMAIN]
+            and self.flow_id in self.hass.data[DOMAIN]["auth_sessions"]
+        ):
+            session_data = self.hass.data[DOMAIN]["auth_sessions"][self.flow_id]
+
+        # Start (or restart on retry) when we have no session yet, or the previous
+        # attempt errored and the user clicked submit on the error step.
+        should_start = session_data is None or (
+            user_input is not None and session_data.get("error")
+        )
+
+        if should_start:
+            self.hass.data.setdefault(DOMAIN, {})
+            self.hass.data[DOMAIN].setdefault("auth_sessions", {})
+
+            if not self._auth_client:
+                # Register HTTP views once per HA process; re-registering raises.
+                if not self.hass.data[DOMAIN].get("views_registered"):
+                    self.hass.http.register_view(EasyIQAuthView(self.hass))
+                    self.hass.http.register_view(EasyIQAuthStatusView(self.hass))
+                    self.hass.http.register_view(
+                        EasyIQAuthSelectIdentityView(self.hass)
+                    )
+                    self.hass.data[DOMAIN]["views_registered"] = True
+
+            self._auth_client = AulaLoginClient(
+                mitid_username=self._mitid_username,
+                mitid_password=self._mitid_password,
+                mitid_token=self._mitid_token,
+                auth_method=self._auth_method,
+                verbose=False,
+                debug=False,
+            )
+
+            session_data = {
+                "client": self._auth_client,
+                "status_message": "Open your MitID app now...",
+                "completed": False,
+                "error": None,
+                "identity_future": None,
+                "available_identities": None,
+            }
+            self.hass.data[DOMAIN]["auth_sessions"][self.flow_id] = session_data
+
+            chosen_identity = self._mitid_identity
+
+            def identity_selector(identity_names):
+                """Block until the web view returns a choice."""
+                # If the configured 1-based index is in range, use it directly.
+                if 1 <= chosen_identity <= len(identity_names):
+                    return str(chosen_identity)
+
+                session_data["available_identities"] = identity_names
+                session_data["status_message"] = "Please select an identity"
+                future: concurrent.futures.Future = concurrent.futures.Future()
+                session_data["identity_future"] = future
+                try:
+                    return future.result(timeout=300)
+                except Exception as err:
+                    _LOGGER.error("Identity selection timed out: %s", err)
+                    raise
+
+            self._auth_client.identity_selector = identity_selector
+
+            # Run authentication in the background; advance the flow when it finishes.
+            self.hass.async_create_task(self._authenticate_async(session_data))
+
+            return self.async_external_step(
+                step_id="authenticate",
+                url=f"/api/aula_easyiq/auth/{self.flow_id}",
+            )
+
+        if session_data.get("completed"):
+            self._tokens = session_data.get("tokens")
+            if not self._tokens:
+                _LOGGER.error("Authentication completed without tokens")
+                return self.async_external_step_done(next_step_id="reauth_error")
+            self.hass.async_create_task(self._delayed_cleanup(self.flow_id))
+            return self.async_external_step_done(next_step_id="complete")
+
+        if session_data.get("error"):
+            return self.async_external_step_done(next_step_id="reauth_error")
+
+        return self.async_external_step(
+            step_id="authenticate",
+            url=f"/api/aula_easyiq/auth/{self.flow_id}",
+        )
+
+    async def async_step_complete(self, user_input=None) -> FlowResult:
+        """Persist tokens + create or update the config entry."""
+        if not self._tokens:
+            return self.async_abort(reason="auth_failed")
+
+        data: dict[str, Any] = {
+            CONF_MITID_USERNAME: self._mitid_username,
+            CONF_AUTH_METHOD: self._auth_method,
+            CONF_ACCESS_TOKEN: self._tokens.get("access_token"),
+            CONF_REFRESH_TOKEN: self._tokens.get("refresh_token", ""),
+            CONF_TOKEN_EXPIRES_AT: self._tokens.get("expires_at", 0),
+            **self._feature_flags,
+        }
+
+        if self._reauth_entry:
+            self.hass.config_entries.async_update_entry(self._reauth_entry, data=data)
+            await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+            return self.async_abort(reason="reauth_successful")
+
+        await self.async_set_unique_id(self._mitid_username)
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=f"EasyIQ ({self._mitid_username})", data=data
+        )
+
+    async def _authenticate_async(self, session_data: dict) -> None:
+        """Run AulaLoginClient.authenticate() in an executor + bookkeep status."""
+        try:
+            monitor_task = self.hass.async_create_task(
+                self._monitor_client_status(session_data)
+            )
+            try:
+                result = await self.hass.async_add_executor_job(
+                    self._auth_client.authenticate
+                )
+            finally:
+                monitor_task.cancel()
+
+            if result.get("success"):
+                session_data["tokens"] = result.get("tokens")
+                session_data["completed"] = True
+                session_data["status_message"] = "Authentication successful!"
+            else:
+                session_data["error"] = result.get("error", "Unknown error")
+        except Exception as err:
+            _LOGGER.error("MitID authentication error: %s", err)
+            session_data["error"] = str(err)
+
+        # Advance the flow regardless of outcome.
+        self.hass.async_create_task(
+            self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+        )
+
+    async def _monitor_client_status(self, session_data: dict) -> None:
+        """Mirror AulaLoginClient.status_message into the session for the web view."""
+        client = session_data["client"]
+        while True:
+            try:
+                mitid_client = client.get_mitid_client()
+                if mitid_client and hasattr(mitid_client, "status_message"):
+                    if not session_data.get("available_identities"):
+                        session_data["status_message"] = mitid_client.status_message
+            except Exception:
+                pass
+            await asyncio.sleep(1)
+
+    async def _delayed_cleanup(self, flow_id: str) -> None:
+        """Clean the auth session a minute after success."""
+        await asyncio.sleep(60)
+        sessions = self.hass.data.get(DOMAIN, {}).get("auth_sessions", {})
+        sessions.pop(flow_id, None)
+
+    async def async_step_reauth_error(self, user_input=None) -> FlowResult:
+        """Show error and let the user retry."""
+        if user_input is not None:
+            return await self.async_step_authenticate(user_input)
+        return self.async_show_form(
+            step_id="reauth_error",
+            errors={"base": "auth_failed"},
+        )
+
+    async def async_step_reauth(self, entry_data) -> FlowResult:
+        """Triggered by ConfigEntryAuthFailed during setup."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if self._reauth_entry:
+            self._mitid_username = self._reauth_entry.data.get(CONF_MITID_USERNAME)
+            self._auth_method = self._reauth_entry.data.get(
+                CONF_AUTH_METHOD, AUTH_METHOD_APP
+            )
+            self._mitid_identity = self._reauth_entry.data.get(
+                CONF_MITID_IDENTITY, 1
+            )
+            self._feature_flags = {
+                CONF_SCHOOLSCHEDULE: self._reauth_entry.data.get(
+                    CONF_SCHOOLSCHEDULE, True
+                ),
+                CONF_WEEKPLAN: self._reauth_entry.data.get(CONF_WEEKPLAN, True),
+                CONF_HOMEWORK: self._reauth_entry.data.get(CONF_HOMEWORK, True),
+                CONF_PRESENCE: self._reauth_entry.data.get(CONF_PRESENCE, True),
+                CONF_MITID_USE_TOKEN: self._reauth_entry.data.get(
+                    CONF_MITID_USE_TOKEN, False
+                ),
+                CONF_MITID_IDENTITY: self._mitid_identity,
+            }
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
+        """Confirm reauth and start authentication."""
+        if user_input is not None:
+            sessions = self.hass.data.get(DOMAIN, {}).get("auth_sessions", {})
+            sessions.pop(self.flow_id, None)
+            if self._auth_method == AUTH_METHOD_TOKEN:
+                return await self.async_step_token_credentials()
+            return await self.async_step_authenticate()
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            description_placeholders={"username": self._mitid_username or ""},
         )
 
     @staticmethod
     def async_get_options_flow(
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
-        """Create the options flow."""
         return OptionsFlowHandler(config_entry)
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    """EasyIQ config flow options handler."""
+    """EasyIQ options handler (intervals + days forward)."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
         super().__init__()
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
@@ -143,34 +387,45 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     ): bool,
                     vol.Optional(
                         CONF_WEEKPLAN_INTERVAL,
-                        default=self._get_option(CONF_WEEKPLAN_INTERVAL, DEFAULT_WEEKPLAN_INTERVAL),
+                        default=self._get_option(
+                            CONF_WEEKPLAN_INTERVAL, DEFAULT_WEEKPLAN_INTERVAL
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=60, max=3600)),
                     vol.Optional(
                         CONF_HOMEWORK_INTERVAL,
-                        default=self._get_option(CONF_HOMEWORK_INTERVAL, DEFAULT_HOMEWORK_INTERVAL),
+                        default=self._get_option(
+                            CONF_HOMEWORK_INTERVAL, DEFAULT_HOMEWORK_INTERVAL
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=60, max=3600)),
                     vol.Optional(
                         CONF_PRESENCE_INTERVAL,
-                        default=self._get_option(CONF_PRESENCE_INTERVAL, DEFAULT_PRESENCE_INTERVAL),
+                        default=self._get_option(
+                            CONF_PRESENCE_INTERVAL, DEFAULT_PRESENCE_INTERVAL
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=60, max=3600)),
                     vol.Optional(
                         CONF_MESSAGES_INTERVAL,
-                        default=self._get_option(CONF_MESSAGES_INTERVAL, DEFAULT_MESSAGES_INTERVAL),
+                        default=self._get_option(
+                            CONF_MESSAGES_INTERVAL, DEFAULT_MESSAGES_INTERVAL
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=60, max=3600)),
                     vol.Optional(
                         CONF_WEEKPLAN_DAYS,
-                        default=self._get_option(CONF_WEEKPLAN_DAYS, DEFAULT_WEEKPLAN_DAYS),
+                        default=self._get_option(
+                            CONF_WEEKPLAN_DAYS, DEFAULT_WEEKPLAN_DAYS
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=1, max=14)),
                     vol.Optional(
                         CONF_HOMEWORK_DAYS,
-                        default=self._get_option(CONF_HOMEWORK_DAYS, DEFAULT_HOMEWORK_DAYS),
+                        default=self._get_option(
+                            CONF_HOMEWORK_DAYS, DEFAULT_HOMEWORK_DAYS
+                        ),
                     ): vol.All(vol.Coerce(int), vol.Range(min=1, max=14)),
                 }
             ),
         )
 
     def _get_option(self, key: str, default: Any) -> Any:
-        """Get option value from config entry."""
         return self.config_entry.options.get(key, default)
 
 

--- a/custom_components/aula_easyiq/config_flow.py
+++ b/custom_components/aula_easyiq/config_flow.py
@@ -129,17 +129,24 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="token_credentials", data_schema=TOKEN_CREDENTIALS_SCHEMA
         )
 
+    def _get_auth_session(self) -> dict | None:
+        """Return the in-progress auth session for this flow_id, if any."""
+        return (
+            self.hass.data.get(DOMAIN, {})
+            .get("auth_sessions", {})
+            .get(self.flow_id)
+        )
+
+    def _drop_auth_session(self) -> None:
+        """Discard the auth session for this flow_id."""
+        sessions = self.hass.data.get(DOMAIN, {}).get("auth_sessions", {})
+        sessions.pop(self.flow_id, None)
+
     async def async_step_authenticate(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Run the actual MitID OAuth flow, surfacing QR codes via a web view."""
-        session_data = None
-        if (
-            DOMAIN in self.hass.data
-            and "auth_sessions" in self.hass.data[DOMAIN]
-            and self.flow_id in self.hass.data[DOMAIN]["auth_sessions"]
-        ):
-            session_data = self.hass.data[DOMAIN]["auth_sessions"][self.flow_id]
+        session_data = self._get_auth_session()
 
         # Start (or restart on retry) when we have no session yet, or the previous
         # attempt errored and the user clicked submit on the error step.
@@ -212,11 +219,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._tokens = session_data.get("tokens")
             if not self._tokens:
                 _LOGGER.error("Authentication completed without tokens")
+                self._drop_auth_session()
                 return self.async_external_step_done(next_step_id="reauth_error")
             self.hass.async_create_task(self._delayed_cleanup(self.flow_id))
             return self.async_external_step_done(next_step_id="complete")
 
         if session_data.get("error"):
+            self._drop_auth_session()
             return self.async_external_step_done(next_step_id="reauth_error")
 
         return self.async_external_step(
@@ -280,12 +289,19 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _monitor_client_status(self, session_data: dict) -> None:
         """Mirror AulaLoginClient.status_message into the session for the web view."""
         client = session_data["client"]
+        last_message = session_data.get("status_message")
         while True:
             try:
                 mitid_client = client.get_mitid_client()
-                if mitid_client and hasattr(mitid_client, "status_message"):
-                    if not session_data.get("available_identities"):
-                        session_data["status_message"] = mitid_client.status_message
+                if (
+                    mitid_client
+                    and hasattr(mitid_client, "status_message")
+                    and not session_data.get("available_identities")
+                ):
+                    message = mitid_client.status_message
+                    if message and message != last_message:
+                        session_data["status_message"] = message
+                        last_message = message
             except Exception:
                 pass
             await asyncio.sleep(1)
@@ -335,8 +351,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_reauth_confirm(self, user_input=None) -> FlowResult:
         """Confirm reauth and start authentication."""
         if user_input is not None:
-            sessions = self.hass.data.get(DOMAIN, {}).get("auth_sessions", {})
-            sessions.pop(self.flow_id, None)
+            self._drop_auth_session()
             if self._auth_method == AUTH_METHOD_TOKEN:
                 return await self.async_step_token_credentials()
             return await self.async_step_authenticate()

--- a/custom_components/aula_easyiq/const.py
+++ b/custom_components/aula_easyiq/const.py
@@ -39,8 +39,24 @@ CONF_SCHOOLSCHEDULE = "schoolschedule"
 CONF_WEEKPLAN = "weekplan"
 CONF_HOMEWORK = "homework"
 CONF_PRESENCE = "presence"
+# Legacy unilogin keys, kept only for migrating old config entries.
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+
+# MitID authentication keys
+CONF_MITID_USERNAME = "mitid_username"
+CONF_MITID_PASSWORD = "mitid_password"  # Optional, for TOKEN method
+CONF_MITID_TOKEN = "mitid_token"  # Optional, for TOKEN method (code reader device)
+CONF_AUTH_METHOD = "auth_method"
+CONF_MITID_USE_TOKEN = "mitid_use_token"
+CONF_MITID_IDENTITY = "mitid_identity"  # 1-based index when several identities exist
+AUTH_METHOD_APP = "APP"
+AUTH_METHOD_TOKEN = "TOKEN"
+
+# Token storage keys (persisted in config entry data)
+CONF_ACCESS_TOKEN = "access_token"
+CONF_REFRESH_TOKEN = "refresh_token"
+CONF_TOKEN_EXPIRES_AT = "token_expires_at"
 
 # Update interval configuration keys
 CONF_WEEKPLAN_INTERVAL = "weekplan_interval"

--- a/custom_components/aula_easyiq/manifest.json
+++ b/custom_components/aula_easyiq/manifest.json
@@ -10,8 +10,15 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/esbenwiberg/easyiq/issues",
-  "requirements": ["aiohttp>=3.8.0"],
+  "requirements": [
+    "aiohttp>=3.8.0",
+    "beautifulsoup4>=4.10.0",
+    "lxml>=4.9.0",
+    "pycryptodome>=3.18.0",
+    "qrcode>=7.4.2",
+    "requests>=2.28.0"
+  ],
   "ssdp": [],
-  "version": "0.4.0",
+  "version": "0.5.0",
   "zeroconf": []
 }

--- a/custom_components/aula_easyiq/strings.json
+++ b/custom_components/aula_easyiq/strings.json
@@ -1,22 +1,49 @@
 {
   "config": {
     "error": {
-      "cannot_connect": "Failed to connect to EasyIQ",
-      "invalid_auth": "Invalid authentication credentials",
+      "cannot_connect": "Failed to connect to Aula/EasyIQ",
+      "invalid_auth": "MitID authentication failed",
+      "auth_failed": "MitID authentication failed. Please try again.",
       "unknown": "Unexpected error occurred"
+    },
+    "abort": {
+      "already_configured": "This MitID account is already configured",
+      "reauth_successful": "Re-authentication was successful",
+      "auth_failed": "Authentication did not return tokens"
     },
     "step": {
       "user": {
         "data": {
-          "username": "Unilogin username",
-          "password": "Unilogin password",
+          "mitid_username": "MitID username",
+          "mitid_use_token": "Use MitID code reader (token) instead of MitID app",
+          "mitid_identity": "Identity number to use (1-based, when several identities exist)",
           "schoolschedule": "School schedules as calendar entities",
           "weekplan": "Weekplans as sensor attributes",
           "homework": "Homework as sensor attributes",
           "presence": "Presence/attendance as sensor attributes"
         },
-        "description": "Enter your Unilogin credentials to connect to EasyIQ",
-        "title": "Authentication"
+        "description": "Aula now requires MitID authentication. Enter your MitID username; you'll authorize the login from your MitID app on the next page (or with a code reader if you enabled the option).",
+        "title": "MitID Authentication"
+      },
+      "token_credentials": {
+        "data": {
+          "mitid_password": "MitID password",
+          "mitid_token": "6-digit code from your code reader"
+        },
+        "description": "Enter your MitID password and the 6-digit code displayed on your MitID code reader device.",
+        "title": "MitID code reader"
+      },
+      "authenticate": {
+        "title": "Authenticating with MitID",
+        "description": "Open the link to scan the MitID QR code with your MitID app, or wait while the code-reader login completes."
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with MitID",
+        "description": "Your Aula tokens for {username} have expired. Click submit to start a new MitID login."
+      },
+      "reauth_error": {
+        "title": "MitID authentication failed",
+        "description": "The MitID login did not complete. Click submit to try again."
       }
     }
   },

--- a/custom_components/aula_easyiq/translations/en.json
+++ b/custom_components/aula_easyiq/translations/en.json
@@ -27,22 +27,49 @@
   },
   "config": {
     "error": {
-      "cannot_connect": "Failed to connect to EasyIQ",
-      "invalid_auth": "Invalid authentication credentials",
+      "cannot_connect": "Failed to connect to Aula/EasyIQ",
+      "invalid_auth": "MitID authentication failed",
+      "auth_failed": "MitID authentication failed. Please try again.",
       "unknown": "Unexpected error occurred"
+    },
+    "abort": {
+      "already_configured": "This MitID account is already configured",
+      "reauth_successful": "Re-authentication was successful",
+      "auth_failed": "Authentication did not return tokens"
     },
     "step": {
       "user": {
         "data": {
-          "username": "Unilogin username",
-          "password": "Unilogin password",
+          "mitid_username": "MitID username",
+          "mitid_use_token": "Use MitID code reader (token) instead of MitID app",
+          "mitid_identity": "Identity number to use (1-based, when several identities exist)",
           "schoolschedule": "School schedules as calendar entities",
           "weekplan": "Weekplans as sensor attributes",
           "homework": "Homework as sensor attributes",
           "presence": "Presence/attendance as sensor attributes"
         },
-        "description": "Enter your Unilogin credentials to connect to EasyIQ",
-        "title": "Authentication"
+        "description": "Aula now requires MitID authentication. Enter your MitID username; you'll authorize the login from your MitID app on the next page (or with a code reader if you enabled the option).",
+        "title": "MitID Authentication"
+      },
+      "token_credentials": {
+        "data": {
+          "mitid_password": "MitID password",
+          "mitid_token": "6-digit code from your code reader"
+        },
+        "description": "Enter your MitID password and the 6-digit code displayed on your MitID code reader device.",
+        "title": "MitID code reader"
+      },
+      "authenticate": {
+        "title": "Authenticating with MitID",
+        "description": "Open the link to scan the MitID QR code with your MitID app, or wait while the code-reader login completes."
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with MitID",
+        "description": "Your Aula tokens for {username} have expired. Click submit to start a new MitID login."
+      },
+      "reauth_error": {
+        "title": "MitID authentication failed",
+        "description": "The MitID login did not complete. Click submit to try again."
       }
     }
   },

--- a/custom_components/aula_easyiq/views.py
+++ b/custom_components/aula_easyiq/views.py
@@ -1,0 +1,218 @@
+"""HTTP views used by the MitID auth config flow.
+
+These views render the MitID QR code (for the APP method) and let the
+user pick an identity when several are bound to the MitID account.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from aiohttp import web
+
+from homeassistant.components.http import HomeAssistantView
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EasyIQAuthView(HomeAssistantView):
+    """Render the MitID auth page (QR codes, status, identity selection)."""
+
+    url = "/api/aula_easyiq/auth/{flow_id}"
+    name = "api:aula_easyiq:auth"
+    requires_auth = False
+
+    def __init__(self, hass):
+        self.hass = hass
+
+    async def get(self, request, flow_id):
+        if (
+            DOMAIN not in self.hass.data
+            or "auth_sessions" not in self.hass.data[DOMAIN]
+            or flow_id not in self.hass.data[DOMAIN]["auth_sessions"]
+        ):
+            return web.Response(status=404, text="Session not found or expired.")
+
+        return web.Response(body=self._get_html(flow_id), content_type="text/html")
+
+    def _get_html(self, flow_id):
+        return f"""
+<!DOCTYPE html>
+<html>
+<head>
+    <title>EasyIQ MitID Authentication</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; text-align: center; padding: 20px; background-color: #f5f5f5; }}
+        .container {{ max-width: 600px; margin: 0 auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }}
+        #qr-container {{ margin: 20px auto; min-height: 200px; display: flex; align-items: center; justify-content: center; }}
+        #qr-container svg {{ max-width: 100%; height: auto; }}
+        .hidden {{ display: none !important; }}
+        #status {{ font-weight: 500; margin: 20px 0; font-size: 1.2em; color: #333; }}
+        button {{ background-color: #03a9f4; color: white; border: none; padding: 10px 20px; margin: 5px; border-radius: 4px; cursor: pointer; font-size: 16px; }}
+        button:hover {{ background-color: #0288d1; }}
+        .error {{ color: #d32f2f; }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>EasyIQ MitID Login</h1>
+        <div id="status">Open your MitID app now...</div>
+        <div id="qr-container"></div>
+        <div id="identity-selection" class="hidden">
+            <h3>Select Identity</h3>
+            <div id="identity-buttons"></div>
+        </div>
+    </div>
+
+    <script>
+        const flowId = "{flow_id}";
+
+        function updateStatus() {{
+            fetch(`/api/aula_easyiq/auth/${{flowId}}/status`)
+                .then(response => response.json())
+                .then(data => {{
+                    if (data.error) {{
+                        document.getElementById("status").innerText = data.error;
+                        document.getElementById("status").className = "error";
+                        return;
+                    }}
+
+                    if (data.message) {{
+                        document.getElementById("status").innerText = data.message;
+                    }}
+
+                    if (data.qr_svg) {{
+                        document.getElementById("qr-container").innerHTML = data.qr_svg;
+                        document.getElementById("qr-container").classList.remove("hidden");
+                        document.getElementById("identity-selection").classList.add("hidden");
+                    }} else {{
+                        document.getElementById("qr-container").innerHTML = "";
+                    }}
+
+                    if (data.identities && data.identities.length > 0) {{
+                        const container = document.getElementById("identity-buttons");
+                        container.innerHTML = "";
+                        data.identities.forEach((name, index) => {{
+                            const btn = document.createElement("button");
+                            btn.innerText = name;
+                            btn.onclick = () => selectIdentity(index + 1);
+                            container.appendChild(btn);
+                        }});
+                        document.getElementById("identity-selection").classList.remove("hidden");
+                        document.getElementById("qr-container").classList.add("hidden");
+                    }}
+
+                    if (data.completed) {{
+                        document.getElementById("status").innerText = "Authentication successful! You can close this window.";
+                        document.getElementById("qr-container").classList.add("hidden");
+                        document.getElementById("identity-selection").classList.add("hidden");
+                        if (!document.getElementById("close-btn")) {{
+                            const btn = document.createElement("button");
+                            btn.id = "close-btn";
+                            btn.innerText = "Close Window";
+                            btn.onclick = () => window.close();
+                            document.querySelector(".container").appendChild(btn);
+                        }}
+                        return;
+                    }}
+
+                    setTimeout(updateStatus, 1000);
+                }})
+                .catch(err => {{
+                    console.error(err);
+                    setTimeout(updateStatus, 2000);
+                }});
+        }}
+
+        function selectIdentity(index) {{
+            fetch(`/api/aula_easyiq/auth/${{flowId}}/select_identity`, {{
+                method: "POST",
+                headers: {{ "Content-Type": "application/json" }},
+                body: JSON.stringify({{ identity: index }})
+            }});
+            document.getElementById("identity-selection").classList.add("hidden");
+            document.getElementById("status").innerText = "Identity selected, continuing...";
+        }}
+
+        updateStatus();
+    </script>
+</body>
+</html>
+        """
+
+
+class EasyIQAuthStatusView(HomeAssistantView):
+    """JSON status endpoint polled by the auth page."""
+
+    url = "/api/aula_easyiq/auth/{flow_id}/status"
+    name = "api:aula_easyiq:auth:status"
+    requires_auth = False
+
+    def __init__(self, hass):
+        self.hass = hass
+
+    async def get(self, request, flow_id):
+        if (
+            DOMAIN not in self.hass.data
+            or "auth_sessions" not in self.hass.data[DOMAIN]
+            or flow_id not in self.hass.data[DOMAIN]["auth_sessions"]
+        ):
+            return web.json_response(
+                {"error": "Session expired or not found"}, status=404
+            )
+
+        session = self.hass.data[DOMAIN]["auth_sessions"][flow_id]
+        client = session["client"]
+
+        qr_svg = None
+        if not session.get("available_identities"):
+            if hasattr(client, "get_qr_codes_svg"):
+                svgs = client.get_qr_codes_svg()
+                if svgs:
+                    # Rotate between the two QR codes once per second.
+                    idx = int(time.time()) % 2
+                    qr_svg = svgs[idx]
+
+        response = {
+            "message": session.get("status_message", "Processing..."),
+            "qr_svg": qr_svg,
+            "identities": session.get("available_identities", []),
+            "completed": session.get("completed", False),
+            "error": session.get("error"),
+        }
+        return web.json_response(response)
+
+
+class EasyIQAuthSelectIdentityView(HomeAssistantView):
+    """Receive identity-selection clicks from the auth page."""
+
+    url = "/api/aula_easyiq/auth/{flow_id}/select_identity"
+    name = "api:aula_easyiq:auth:select_identity"
+    requires_auth = False
+
+    def __init__(self, hass):
+        self.hass = hass
+
+    async def post(self, request, flow_id):
+        if (
+            DOMAIN not in self.hass.data
+            or "auth_sessions" not in self.hass.data[DOMAIN]
+            or flow_id not in self.hass.data[DOMAIN]["auth_sessions"]
+        ):
+            return web.json_response({"error": "Session not found"}, status=404)
+
+        data = await request.json()
+        identity_index = data.get("identity")
+
+        session = self.hass.data[DOMAIN]["auth_sessions"][flow_id]
+        future = session.get("identity_future")
+
+        if future and not future.done():
+            future.set_result(str(identity_index))
+            session["available_identities"] = None
+
+        return web.json_response({"status": "ok"})


### PR DESCRIPTION
Aula has deprecated password-based Unilogin authentication, so this
integration's auth no longer works. Mirror what scaarup/aula did and
move to the MitID OAuth 2.0 + SAML flow.

- Vendor scaarup/aula's `aula_login_client` package (incl. the
  `mitid_browserclient` SRP/QR implementation) for the MitID flow.
- Refactor `client.py` to drive AulaLoginClient: stored-token reuse,
  refresh-token renewal, and full re-authentication when needed. Aula
  API calls now pass `access_token` as a query parameter.
- Multi-step config flow: MitID app (QR scan) and MitID code reader
  (TOKEN) methods, served via new `views.py` at
  `/api/aula_easyiq/auth/<flow_id>`. Auto-reauth via
  ConfigEntryAuthFailed when refresh fails.
- Bump config entry to VERSION 2 with mitid_username, auth_method,
  access_token, refresh_token, token_expires_at. Old unilogin entries
  trigger a reauth prompt on next setup.
- manifest.json gains pycryptodome, qrcode, requests, beautifulsoup4,
  lxml. Strings/translations updated for the new flow.

https://claude.ai/code/session_011qQCswtDsUxwD3ex8b8UfF