### PR TITLE
[codex] improve agent validation workflow

### DIFF
--- a/.github/workflows/local-validation.yaml
+++ b/.github/workflows/local-validation.yaml
@@ -1,0 +1,18 @@
+name: Local validation
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Run offline validation contract
+        run: ./scripts/validate.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+See [CLAUDE.md](./CLAUDE.md). It is the single source of truth for how agents
+work in this repo: validation contract, test pyramid, live-account boundaries,
+and the Home Assistant integration trip-wires.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# CLAUDE.md - EasyIQ Home Assistant Integration
+
+This is a Home Assistant custom integration for Aula + EasyIQ. The integration
+domain and folder are `aula_easyiq`.
+
+Read this before changing code.
+
+## Self-validation
+
+The standard local contract is:
+
+```bash
+./scripts/validate.sh
+```
+
+It runs:
+
+| Gate | What it checks |
+| ---- | -------------- |
+| Python version | Python 3.11+ so the source syntax matches the project contract |
+| Syntax | `compileall` over `custom_components`, `scripts`, and `tests` |
+| HA structure | Manifest, required integration files, config flow, sensors, translations |
+| Offline unit tests | Pure stdlib tests under `tests/unit`, no Home Assistant or network required |
+| HA import smoke | Runs only when Home Assistant is installed locally |
+
+Any non-zero exit means the work is not done.
+
+## First-clone setup
+
+For the full local toolchain:
+
+```bash
+./scripts/bootstrap-dev.sh
+./scripts/validate.sh
+```
+
+The offline validation lane does not need Aula credentials. Only create `.env`
+when you intentionally run live API or Home Assistant development flows:
+
+```bash
+cp .env.template .env
+python scripts/dev_start.py
+```
+
+## Dev and live checks
+
+Use these only when the change needs that level of confidence:
+
+| Command | Use |
+| ------- | --- |
+| `python scripts/dev_start.py` | Run Home Assistant locally at `http://localhost:8123` with this integration linked in |
+| `python scripts/docker_setup.py` | Start a Docker-backed Home Assistant dev instance |
+| `python scripts/test_client.py` | Opt-in live Aula/EasyIQ API check; requires real credentials in `.env` |
+| `python scripts/debug_helper.py` | Interactive diagnosis for local HA setup and API issues |
+
+Live account scripts must never run in default validation. Keep them explicit
+because they touch real services and real family/school data.
+
+## Test pyramid
+
+1. **Pure unit tests** live in `tests/unit`. They must not import Home Assistant
+   or call the network. Extract pure helpers from integration modules when a
+   behavior deserves fast coverage.
+2. **Home Assistant integration tests** should use `pytest-homeassistant-custom-component`
+   once the behavior needs HA entities, config entries, or coordinator lifecycle.
+3. **Repository validation** is `./scripts/validate.sh`.
+4. **CI validation** uses hassfest and HACS validation from `.github/workflows`.
+5. **Local HA smoke** uses `scripts/dev_start.py` or `scripts/docker_setup.py`.
+6. **Live Aula/EasyIQ smoke** uses `scripts/test_client.py` and is opt-in only.
+
+## Trip-wires
+
+- The integration folder is `custom_components/aula_easyiq`. Do not document or
+  copy `custom_components/easyiq`.
+- Default tests and validation must be credential-free and network-free.
+- Keep real credentials out of fixtures, logs, docs, and screenshots.
+- If code imports a new third-party runtime package, add it to
+  `custom_components/aula_easyiq/manifest.json` and `requirements-dev.txt`.
+- Prefer extracting pure parsing, date, and update-policy logic before testing;
+  Home Assistant imports are expensive and slow for tight agent loops.
+- The client boundary in `client.py` talks to Aula/EasyIQ. Keep request logic
+  isolated so parsing and transformation can be tested offline.
+
+## Coverage map
+
+| Surface | Coverage | Notes |
+| ------- | -------- | ----- |
+| Manifest/runtime dependency contract | Unit tests | `tests/unit/test_manifest_contract.py` |
+| Coordinator update interval policy | Unit tests | `tests/unit/test_update_policy.py` |
+| HA integration structure | Scripted validation | `scripts/validate_ha_integration.py` |
+| Entity behavior | Gap | Add HA integration tests before deep entity refactors |
+| Calendar parsing | Gap | Extract pure parser helpers before expanding coverage |
+| EasyIQ/Aula client parsing | Gap | Extract response mappers before changing API handling |
+| Live authentication | Manual smoke | `scripts/test_client.py`, credentials required |
+
+## Context locations
+
+- `custom_components/aula_easyiq/` - Home Assistant integration source
+- `scripts/` - local setup, validation, debug, and live smoke tools
+- `docs/` - usage guides and implementation notes
+- `.github/workflows/` - hassfest and HACS validation
+- `tests/unit/` - fast offline tests

--- a/DEVELOPMENT_SETUP.md
+++ b/DEVELOPMENT_SETUP.md
@@ -48,8 +48,8 @@ docker run -d --name homeassistant --restart=unless-stopped -e TZ=Europe/Copenha
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-username/easyiq-ha.git
-cd easyiq-ha
+git clone https://github.com/your-username/easyiq.git
+cd easyiq
 
 # Set up credentials
 cp .env.template .env
@@ -87,10 +87,10 @@ mkdir ha-config/custom_components
 
 # Copy the EasyIQ integration
 # Windows PowerShell:
-cp -r custom_components\easyiq ha-config\custom_components\
+cp -r custom_components\aula_easyiq ha-config\custom_components\
 
 # Linux/Mac:
-cp -r custom_components/easyiq ha-config/custom_components/
+cp -r custom_components/aula_easyiq ha-config/custom_components/
 
 # Pull and start Home Assistant
 docker pull homeassistant/home-assistant:latest
@@ -114,7 +114,7 @@ If you don't see "EasyIQ" in the integration list:
 1. **Check the integration is installed**:
    ```bash
    # Verify files are in the right place
-   docker exec homeassistant ls -la /config/custom_components/easyiq/
+   docker exec homeassistant ls -la /config/custom_components/aula_easyiq/
    ```
 
 2. **Restart Home Assistant**:
@@ -130,7 +130,7 @@ If you don't see "EasyIQ" in the integration list:
 4. **Manual configuration** (if UI doesn't work):
    Add to your `ha-config/configuration.yaml`:
    ```yaml
-   easyiq:
+   aula_easyiq:
      username: your_aula_username
      password: your_aula_password
    ```
@@ -139,18 +139,21 @@ If you don't see "EasyIQ" in the integration list:
 
 ### Testing the Integration
 ```bash
-# Test the client directly
+# Run offline validation
+./scripts/validate.sh
+
+# Test the live client directly, with credentials in .env
 python scripts/test_client.py
 
 # Interactive debugging
 python scripts/debug_helper.py
 
 # Validate Home Assistant compatibility
-python scripts/validate_ha_integration.py
+./scripts/validate.sh
 ```
 
 ### Making Changes
-1. Edit files in `custom_components/easyiq/`
+1. Edit files in `custom_components/aula_easyiq/`
 2. Restart Home Assistant (Ctrl+C, then run dev_start script again)
 3. Test changes in the web interface at `http://localhost:8123`
 
@@ -194,12 +197,12 @@ docker run -d --name homeassistant -p 8124:8123 homeassistant/home-assistant:lat
 #### Integration not appearing in UI
 1. **Verify integration is installed**:
    ```bash
-   docker exec homeassistant ls -la /config/custom_components/easyiq/
+   docker exec homeassistant ls -la /config/custom_components/aula_easyiq/
    ```
 
 2. **Check manifest.json is valid**:
    ```bash
-   docker exec homeassistant cat /config/custom_components/easyiq/manifest.json
+   docker exec homeassistant cat /config/custom_components/aula_easyiq/manifest.json
    ```
 
 3. **Restart Home Assistant**:
@@ -221,7 +224,7 @@ docker run -d --name homeassistant -p 8124:8123 homeassistant/home-assistant:lat
 2. **Verify file permissions**:
    ```bash
    # Make sure files are readable
-   chmod -R 755 custom_components/easyiq/
+   chmod -R 755 custom_components/aula_easyiq/
    ```
 
 3. **Test the client directly**:
@@ -257,12 +260,12 @@ python scripts/test_client.py
 python scripts/debug_helper.py
 
 # Validate integration structure
-python scripts/validate_ha_integration.py
+./scripts/validate.sh
 ```
 
 ### Production Testing
 Before releasing, test the integration as users would:
-1. Copy `custom_components/easyiq/` to a real Home Assistant installation
+1. Copy `custom_components/aula_easyiq/` to a real Home Assistant installation
 2. Add the integration through the UI
 3. Verify all sensors and calendar entities work correctly
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Home Assistant custom integration for Aula + EasyIQ school management system, 
 ### Manual Installation
 
 1. Download the latest release from the [releases page](https://github.com/esbenwiberg/easyiq/releases)
-2. Extract the `custom_components/easyiq` folder to your Home Assistant `custom_components` directory
+2. Extract the `custom_components/aula_easyiq` folder to your Home Assistant `custom_components` directory
 3. Restart Home Assistant
 
 ## Quick Start
@@ -109,7 +109,7 @@ This approach reduces API load while keeping important data fresh. The defaults 
 Add to your `configuration.yaml`:
 
 ```yaml
-easyiq:
+aula_easyiq:
   username: your_aula_username
   password: your_aula_password
   school_schedule: true
@@ -422,7 +422,7 @@ sensor:
 
 **Integration Not Loading**
 - Restart Home Assistant after installation
-- Check `custom_components/easyiq` folder structure is correct
+- Check `custom_components/aula_easyiq` folder structure is correct
 - Review Home Assistant logs for import errors
 
 ### Debug Logging
@@ -433,7 +433,7 @@ Add to your `configuration.yaml` for detailed logs:
 logger:
   default: warning
   logs:
-    custom_components.easyiq: debug
+    custom_components.aula_easyiq: debug
 ```
 
 ### Test Script
@@ -441,7 +441,7 @@ logger:
 Run the included test script to verify your credentials:
 
 ```bash
-cd /config/custom_components/easyiq
+cd /config/custom_components/aula_easyiq
 python scripts/test_client.py
 ```
 
@@ -528,18 +528,21 @@ Contributions are welcome! Please:
 
 ```bash
 git clone https://github.com/esbenwiberg/easyiq.git
-cd easyiq-ha
-pip install -r requirements-dev.txt
+cd easyiq
+./scripts/bootstrap-dev.sh
 ```
 
 ### Testing
 
 ```bash
-# Test the client
-python scripts/test_client.py
+# Run the offline validation contract
+./scripts/validate.sh
+
+# Opt-in live API smoke; requires credentials in .env
+.venv/bin/python scripts/test_client.py
 
 # Run with debug logging
-python -c "import logging; logging.basicConfig(level=logging.DEBUG); exec(open('scripts/test_client.py').read())"
+.venv/bin/python -c "import logging; logging.basicConfig(level=logging.DEBUG); exec(open('scripts/test_client.py').read())"
 ```
 
 ## License

--- a/custom_components/aula_easyiq/const.py
+++ b/custom_components/aula_easyiq/const.py
@@ -13,7 +13,7 @@ EasyIQ integration, version: %s
 This is a custom integration for EasyIQ
 Based on the Aula component with fixes for EasyIQ integration issues
 If you have any issues with this you need to open an issue here:
-https://github.com/easyiq/easyiq-ha/issues
+https://github.com/esbenwiberg/easyiq/issues
 -------------------------------------------------------------------
 """
 

--- a/custom_components/aula_easyiq/manifest.json
+++ b/custom_components/aula_easyiq/manifest.json
@@ -10,7 +10,13 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/esbenwiberg/easyiq/issues",
-  "requirements": ["aiohttp>=3.8.0"],
+  "requirements": [
+    "aiohttp>=3.8.0",
+    "beautifulsoup4>=4.11.0",
+    "lxml>=4.9.0",
+    "pytz>=2023.3",
+    "requests>=2.28.0"
+  ],
   "ssdp": [],
   "version": "0.4.0",
   "zeroconf": []

--- a/custom_components/aula_easyiq/sensor.py
+++ b/custom_components/aula_easyiq/sensor.py
@@ -33,6 +33,7 @@ from .const import (
     DEFAULT_HOMEWORK_DAYS,
     DOMAIN,
 )
+from .update_policy import should_update_data_type
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,19 +126,24 @@ class EasyIQDataUpdateCoordinator(DataUpdateCoordinator):
     def _should_update_data_type(self, data_type: str) -> bool:
         """Check if a specific data type should be updated based on its interval."""
         try:
+            should_update = should_update_data_type(
+                data_type,
+                self.update_intervals,
+                self.last_updates,
+            )
+
             if data_type not in self.update_intervals:
                 _LOGGER.debug(f"Data type {data_type} not in update_intervals, updating by default")
-                return True
+                return should_update
                 
             last_update = self.last_updates.get(data_type)
             if last_update is None:
                 _LOGGER.debug(f"No last update time for {data_type}, updating")
-                return True
+                return should_update
                 
             interval = self.update_intervals[data_type]
             time_since_update = (datetime.now() - last_update).total_seconds()
             
-            should_update = time_since_update >= interval
             if should_update:
                 _LOGGER.debug(f"Should update {data_type}: {time_since_update:.1f}s >= {interval}s")
             else:
@@ -328,6 +334,5 @@ class EasyIQStatusSensor(CoordinatorEntity, SensorEntity):
             "last_update_success": self.coordinator.last_update_success,
             "last_exception": str(self.coordinator.last_exception) if self.coordinator.last_exception else None,
         }
-
 
 

--- a/custom_components/aula_easyiq/strings.json
+++ b/custom_components/aula_easyiq/strings.json
@@ -1,4 +1,30 @@
 {
+  "services": {
+    "api_call": {
+      "name": "API Call",
+      "description": "Make a custom API call to EasyIQ",
+      "fields": {
+        "uri": {
+          "name": "URI",
+          "description": "URI for the API call"
+        },
+        "post_data": {
+          "name": "POST Data",
+          "description": "JSON formatted post data, if not defined, request will be GET"
+        }
+      }
+    },
+    "refresh_data": {
+      "name": "Refresh Data",
+      "description": "Force refresh of all EasyIQ data",
+      "fields": {
+        "child_id": {
+          "name": "Child ID",
+          "description": "Specific child ID to refresh data for (optional, refreshes all if not specified)"
+        }
+      }
+    }
+  },
   "config": {
     "error": {
       "cannot_connect": "Failed to connect to EasyIQ",

--- a/custom_components/aula_easyiq/update_policy.py
+++ b/custom_components/aula_easyiq/update_policy.py
@@ -1,0 +1,27 @@
+"""Update interval policy helpers for the EasyIQ coordinator."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping
+
+
+def should_update_data_type(
+    data_type: str,
+    update_intervals: Mapping[str, int],
+    last_updates: Mapping[str, datetime | None],
+    now: datetime | None = None,
+) -> bool:
+    """Return whether a data type is due for refresh."""
+    if data_type not in update_intervals:
+        return True
+
+    last_update = last_updates.get(data_type)
+    if last_update is None:
+        return True
+
+    interval = update_intervals[data_type]
+    if interval <= 0:
+        return True
+
+    current_time = now or datetime.now()
+    return (current_time - last_update).total_seconds() >= interval

--- a/docs/testing-pyramid.md
+++ b/docs/testing-pyramid.md
@@ -1,0 +1,98 @@
+# EasyIQ Test Pyramid
+
+EasyIQ needs fast checks for autonomous agents and slower checks for Home
+Assistant and live EasyIQ behavior. Keep the lower layers credential-free.
+
+## 1. Offline Unit Tests
+
+Command:
+
+```bash
+./scripts/validate.sh
+```
+
+Scope:
+
+- Pure update policy, date, parser, and formatting helpers.
+- Manifest and translation contracts.
+- No Home Assistant import.
+- No network.
+- No `.env`.
+
+Add tests here first whenever behavior can be extracted from HA classes.
+
+## 2. Home Assistant Integration Tests
+
+Command, once tests exist:
+
+```bash
+.venv/bin/python -m pytest
+```
+
+Scope:
+
+- Config flow behavior.
+- Entity setup and unique IDs.
+- Coordinator lifecycle with fake clients.
+- Calendar and binary sensor behavior against HA objects.
+
+Use `pytest-homeassistant-custom-component` and fake the EasyIQ client. These
+tests should still avoid live Aula/EasyIQ traffic.
+
+## 3. Repository Validation
+
+Command:
+
+```bash
+./scripts/validate.sh
+```
+
+Scope:
+
+- Python 3.11+ enforcement.
+- Syntax compilation with bytecode cached inside the repo.
+- Home Assistant structure validation.
+- Offline unit tests.
+- HA import smoke when dependencies are installed.
+
+## 4. Hassfest and HACS Validation
+
+Scope:
+
+- Home Assistant custom integration packaging rules.
+- HACS repository rules.
+
+These run in GitHub Actions and complement local validation.
+
+## 5. Local Home Assistant Smoke
+
+Commands:
+
+```bash
+python scripts/dev_start.py
+python scripts/docker_setup.py
+```
+
+Scope:
+
+- The integration appears in Home Assistant.
+- Config flow renders.
+- Entities load after setup.
+- Logs are clean enough to diagnose failures.
+
+This layer can use `.env` credentials but should be run intentionally.
+
+## 6. Live Aula/EasyIQ Smoke
+
+Command:
+
+```bash
+python scripts/test_client.py
+```
+
+Scope:
+
+- Authentication still works.
+- Children, weekplan, homework, presence, and messages can be fetched.
+
+This is opt-in only because it touches real services and real user data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+# Development and validation requirements for EasyIQ.
+
+homeassistant>=2024.1.0
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+pytest-homeassistant-custom-component>=0.13.0
+ruff>=0.8.0
+mypy>=1.13.0
+
+# Runtime dependencies declared in custom_components/aula_easyiq/manifest.json.
+aiohttp>=3.8.0
+beautifulsoup4>=4.11.0
+lxml>=4.9.0
+pytz>=2023.3
+requests>=2.28.0

--- a/scripts/bootstrap-dev.sh
+++ b/scripts/bootstrap-dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -n "${PYTHON:-}" ]]; then
+  PYTHON_BIN="$PYTHON"
+elif command -v python3.12 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3.12)"
+elif command -v python3.11 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3.11)"
+else
+  echo "Python 3.11+ is required. Install Python 3.11+ or set PYTHON=/path/to/python." >&2
+  exit 1
+fi
+
+"$PYTHON_BIN" - <<'PY'
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit(f"Python 3.11+ is required; found {sys.version.split()[0]}")
+PY
+
+"$PYTHON_BIN" -m venv .venv
+.venv/bin/python -m pip install --upgrade pip
+.venv/bin/python -m pip install -r requirements-dev.txt
+
+echo "Development environment ready. Run ./scripts/validate.sh next."

--- a/scripts/dev_setup.py
+++ b/scripts/dev_setup.py
@@ -10,6 +10,17 @@ import subprocess
 import json
 from pathlib import Path
 
+def write_text_if_missing(path: Path, content: str, executable: bool = False) -> None:
+    """Write generated setup files without overwriting committed scripts."""
+    if path.exists():
+        print(f"{path} already exists; leaving it unchanged")
+        return
+
+    path.write_text(content)
+    if executable and os.name != 'nt':
+        os.chmod(path, 0o755)
+    print(f"Created {path}")
+
 def create_env_file():
     """Create a .env file template for development."""
     env_content = """# EasyIQ Development Environment Variables
@@ -31,10 +42,7 @@ EASYIQ_MOCK_MODE=false
 """
     
     env_file = Path(".env.template")
-    with open(env_file, "w") as f:
-        f.write(env_content)
-    
-    print(f"Created {env_file}")
+    write_text_if_missing(env_file, env_content)
     print("Copy this to .env and fill in your credentials")
 
 def create_dev_script():
@@ -73,14 +81,7 @@ python -m homeassistant --config "$HASS_CONFIG_DIR" --debug
 """
     
     script_file = Path("scripts/dev_start.sh")
-    with open(script_file, "w") as f:
-        f.write(script_content)
-    
-    # Make script executable on Unix systems
-    if os.name != 'nt':
-        os.chmod(script_file, 0o755)
-    
-    print(f"Created {script_file}")
+    write_text_if_missing(script_file, script_content, executable=True)
 
 def create_test_script():
     """Create a test script for the EasyIQ client."""
@@ -95,10 +96,10 @@ import sys
 import asyncio
 from pathlib import Path
 
-# Add the custom_components directory to the path
-sys.path.insert(0, str(Path(__file__).parent.parent / "custom_components"))
+# Add the integration directory to the path for standalone client tests
+sys.path.insert(0, str(Path(__file__).parent.parent / "custom_components" / "aula_easyiq"))
 
-from easyiq.client import EasyIQClient
+from client import EasyIQClient
 
 async def test_easyiq_client():
     \"\"\"Test the EasyIQ client with environment variables.\"\"\"
@@ -139,8 +140,8 @@ async def test_easyiq_client():
                 child_id = child.get("id")
                 child_name = child.get("name", "Unknown")
                 print(f"Getting ugeplan for {child_name} (ID: {child_id})...")
-                ugeplan = await client.get_ugeplan(child_id)
-                print(f"Ugeplan data: {ugeplan}")
+                weekplan = await client.get_weekplan(child_id)
+                print(f"Weekplan data: {weekplan}")
         
         return auth_result
         
@@ -172,21 +173,14 @@ if __name__ == "__main__":
 """
     
     script_file = Path("scripts/test_client.py")
-    with open(script_file, "w") as f:
-        f.write(test_content)
-    
-    # Make script executable on Unix systems
-    if os.name != 'nt':
-        os.chmod(script_file, 0o755)
-    
-    print(f"Created {script_file}")
+    write_text_if_missing(script_file, test_content, executable=True)
 
 def create_requirements():
     """Create requirements file for development."""
     requirements_content = """# EasyIQ Development Requirements
 
 # Home Assistant
-homeassistant>=2023.1.0
+homeassistant>=2024.1.0
 
 # Required for EasyIQ integration
 requests>=2.28.0
@@ -200,17 +194,12 @@ pytest-asyncio>=0.20.0
 pytest-homeassistant-custom-component>=0.13.0
 
 # Code quality
-black>=22.0.0
-isort>=5.10.0
-flake8>=5.0.0
-mypy>=0.991
+ruff>=0.8.0
+mypy>=1.13.0
 """
     
     req_file = Path("requirements-dev.txt")
-    with open(req_file, "w") as f:
-        f.write(requirements_content)
-    
-    print(f"Created {req_file}")
+    write_text_if_missing(req_file, requirements_content)
 
 def main():
     """Main setup function."""
@@ -229,9 +218,10 @@ def main():
     print("\nDevelopment setup complete!")
     print("\nNext steps:")
     print("1. Copy .env.template to .env and fill in your credentials")
-    print("2. Install requirements: pip install -r requirements-dev.txt")
+    print("2. Install requirements: ./scripts/bootstrap-dev.sh")
     print("3. Run development server: ./scripts/dev_start.sh")
-    print("4. Test client independently: python scripts/test_client.py")
+    print("4. Validate the repo: ./scripts/validate.sh")
+    print("5. Test the live client independently: python scripts/test_client.py")
 
 if __name__ == "__main__":
     main()

--- a/scripts/dev_start.bat
+++ b/scripts/dev_start.bat
@@ -67,7 +67,7 @@ if not exist "%HASS_CONFIG_DIR%\configuration.yaml" (
         echo logger:
         echo   default: info
         echo   logs:
-        echo     custom_components.easyiq: debug
+        echo     custom_components.aula_easyiq: debug
         echo.
         echo # Development tools
         echo developer_tools:

--- a/scripts/dev_start.ps1
+++ b/scripts/dev_start.ps1
@@ -79,7 +79,7 @@ zone:
 logger:
   default: info
   logs:
-    custom_components.easyiq: debug
+    custom_components.aula_easyiq: debug
 
 # Development tools
 developer_tools:

--- a/scripts/dev_start.sh
+++ b/scripts/dev_start.sh
@@ -48,7 +48,7 @@ zone:
 logger:
   default: info
   logs:
-    custom_components.easyiq: debug
+    custom_components.aula_easyiq: debug
 
 # Development tools
 developer_tools:

--- a/scripts/ha_config_template.yaml
+++ b/scripts/ha_config_template.yaml
@@ -45,7 +45,7 @@ script: !include scripts.yaml
 logger:
   default: info
   logs:
-    custom_components.easyiq: debug
+    custom_components.aula_easyiq: debug
     homeassistant.components.sensor: debug
     homeassistant.helpers.entity_platform: debug
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+find_python() {
+  if [[ -n "${PYTHON:-}" ]]; then
+    echo "$PYTHON"
+    return 0
+  fi
+
+  for candidate in "$ROOT_DIR/.venv/bin/python" python3.12 python3.11 python3; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+
+  echo "No Python interpreter found. Install Python 3.11+ or run scripts/bootstrap-dev.sh." >&2
+  return 1
+}
+
+PYTHON_BIN="$(find_python)"
+
+"$PYTHON_BIN" - <<'PY'
+import sys
+
+if sys.version_info < (3, 11):
+    raise SystemExit(
+        f"Python 3.11+ is required; found {sys.version.split()[0]}. "
+        "Set PYTHON=/path/to/python3.11+ or run scripts/bootstrap-dev.sh."
+    )
+PY
+
+export PYTHONPYCACHEPREFIX="${PYTHONPYCACHEPREFIX:-$ROOT_DIR/.pycache}"
+mkdir -p "$PYTHONPYCACHEPREFIX"
+
+echo "==> Python syntax check"
+"$PYTHON_BIN" -m compileall -q custom_components scripts tests
+
+echo "==> Home Assistant structure validation"
+"$PYTHON_BIN" scripts/validate_ha_integration.py
+
+echo "==> Offline unit tests"
+"$PYTHON_BIN" -m unittest discover -s tests/unit
+
+if "$PYTHON_BIN" -c "import homeassistant" >/dev/null 2>&1; then
+  echo "==> Home Assistant import smoke"
+  "$PYTHON_BIN" - <<'PY'
+import importlib
+
+for module_name in (
+    "custom_components.aula_easyiq",
+    "custom_components.aula_easyiq.binary_sensor",
+    "custom_components.aula_easyiq.calendar",
+    "custom_components.aula_easyiq.config_flow",
+    "custom_components.aula_easyiq.sensor",
+):
+    importlib.import_module(module_name)
+PY
+else
+  echo "==> Skipping Home Assistant import smoke; install requirements-dev.txt to enable it"
+fi
+
+echo "==> Validation complete"

--- a/tests/unit/test_manifest_contract.py
+++ b/tests/unit/test_manifest_contract.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INTEGRATION_DIR = ROOT / "custom_components" / "aula_easyiq"
+
+
+class ManifestContractTests(unittest.TestCase):
+    def test_domain_matches_integration_folder(self) -> None:
+        manifest = json.loads((INTEGRATION_DIR / "manifest.json").read_text())
+
+        self.assertEqual("aula_easyiq", manifest["domain"])
+        self.assertTrue((ROOT / "custom_components" / manifest["domain"]).is_dir())
+
+    def test_runtime_dependencies_cover_imported_third_party_packages(self) -> None:
+        manifest = json.loads((INTEGRATION_DIR / "manifest.json").read_text())
+        requirements = " ".join(manifest.get("requirements", []))
+
+        for package_name in ("aiohttp", "beautifulsoup4", "lxml", "pytz", "requests"):
+            with self.subTest(package_name=package_name):
+                self.assertIn(package_name, requirements)
+
+    def test_strings_and_english_translation_share_config_and_options(self) -> None:
+        strings = json.loads((INTEGRATION_DIR / "strings.json").read_text())
+        english = json.loads((INTEGRATION_DIR / "translations" / "en.json").read_text())
+
+        self.assertEqual(strings["config"], english["config"])
+        self.assertEqual(strings["options"], english["options"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_update_policy.py
+++ b/tests/unit/test_update_policy.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+def load_update_policy_module():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "custom_components"
+        / "aula_easyiq"
+        / "update_policy.py"
+    )
+    spec = importlib.util.spec_from_file_location("easyiq_update_policy", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+update_policy = load_update_policy_module()
+
+
+class ShouldUpdateDataTypeTests(unittest.TestCase):
+    def test_unknown_data_type_updates_by_default(self) -> None:
+        self.assertTrue(
+            update_policy.should_update_data_type(
+                "calendar",
+                {"weekplan": 900},
+                {"weekplan": datetime(2026, 6, 20, 12, 0, 0)},
+                now=datetime(2026, 6, 20, 12, 1, 0),
+            )
+        )
+
+    def test_missing_last_update_is_due(self) -> None:
+        self.assertTrue(
+            update_policy.should_update_data_type(
+                "weekplan",
+                {"weekplan": 900},
+                {"weekplan": None},
+                now=datetime(2026, 6, 20, 12, 0, 0),
+            )
+        )
+
+    def test_skips_before_interval_elapsed(self) -> None:
+        now = datetime(2026, 6, 20, 12, 10, 0)
+
+        self.assertFalse(
+            update_policy.should_update_data_type(
+                "presence",
+                {"presence": 300},
+                {"presence": now - timedelta(seconds=299)},
+                now=now,
+            )
+        )
+
+    def test_updates_when_interval_elapsed(self) -> None:
+        now = datetime(2026, 6, 20, 12, 10, 0)
+
+        self.assertTrue(
+            update_policy.should_update_data_type(
+                "presence",
+                {"presence": 300},
+                {"presence": now - timedelta(seconds=300)},
+                now=now,
+            )
+        )
+
+    def test_zero_or_negative_interval_updates_defensively(self) -> None:
+        now = datetime(2026, 6, 20, 12, 10, 0)
+
+        self.assertTrue(
+            update_policy.should_update_data_type(
+                "messages",
+                {"messages": 0},
+                {"messages": now},
+                now=now,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add an agent operating guide (`CLAUDE.md`) plus `AGENTS.md` pointer describing the validation contract, test pyramid, live-account boundaries, and repo trip-wires.
- Add a credential-free `./scripts/validate.sh` contract, dev bootstrap script, local validation CI workflow, and first offline unit tests.
- Extract coordinator update interval policy into a pure helper so agents can test the behavior without importing Home Assistant.
- Fix docs/scripts to consistently use the real `aula_easyiq` integration folder/domain and declare the runtime dependencies imported by the client.

## Validation

- `./scripts/validate.sh`

The local Home Assistant import smoke is conditional and skips when Home Assistant is not installed in the active interpreter.